### PR TITLE
Add particle editing

### DIFF
--- a/Recombobulator/MainForm.Designer.cs
+++ b/Recombobulator/MainForm.Designer.cs
@@ -38,8 +38,12 @@
 			this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.newProjectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.openProjectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.openFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.addToProjectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.dataFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.openDataFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.addDataFileToProjectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.particlesFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.openParticlesPCFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.saveParticlesFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.scriptedImportsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.importUndercityFeb04ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.importUndercityFeb16ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -66,8 +70,11 @@
 			this.scripts = new System.Windows.Forms.TextBox();
 			this.testResultsTab = new System.Windows.Forms.TabPage();
 			this.testResults = new System.Windows.Forms.TextBox();
+			this.particlesTab = new System.Windows.Forms.TabPage();
+			this.particlesPanel = new Recombobulator.ParticlePanels.MainParticlesPanel();
 			this.projectContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
 			this.editPortalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.openParticlesPSXFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this._mainMenu.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.pcmFileTreeListView)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.pcmFileSplitContainer)).BeginInit();
@@ -83,13 +90,14 @@
 			this.pcmFileDataTab.SuspendLayout();
 			this.scriptsTab.SuspendLayout();
 			this.testResultsTab.SuspendLayout();
+			this.particlesTab.SuspendLayout();
 			this.projectContextMenu.SuspendLayout();
 			this.SuspendLayout();
 			// 
 			// _mainMenu
 			// 
 			this._mainMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.fileToolStripMenuItem});
+			this.fileToolStripMenuItem});
 			this._mainMenu.Location = new System.Drawing.Point(0, 0);
 			this._mainMenu.Name = "_mainMenu";
 			this._mainMenu.Size = new System.Drawing.Size(800, 24);
@@ -99,15 +107,15 @@
 			// fileToolStripMenuItem
 			// 
 			this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.newProjectToolStripMenuItem,
-            this.openProjectToolStripMenuItem,
-            this.openFileToolStripMenuItem,
-            this.addToProjectToolStripMenuItem,
-            this.scriptedImportsToolStripMenuItem,
-            this.compileProjectToolStripMenuItem,
-            this.testExportToolStripMenuItem,
-            this.bulkTestingToolStripMenuItem,
-            this.exitToolStripMenuItem});
+			this.newProjectToolStripMenuItem,
+			this.openProjectToolStripMenuItem,
+			this.dataFileToolStripMenuItem,
+			this.particlesFileToolStripMenuItem,
+			this.scriptedImportsToolStripMenuItem,
+			this.compileProjectToolStripMenuItem,
+			this.testExportToolStripMenuItem,
+			this.bulkTestingToolStripMenuItem,
+			this.exitToolStripMenuItem});
 			this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
 			this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
 			this.fileToolStripMenuItem.Text = "File";
@@ -126,30 +134,64 @@
 			this.openProjectToolStripMenuItem.Text = "Open Project...";
 			this.openProjectToolStripMenuItem.Click += new System.EventHandler(this.OpenProjectToolStripMenuItem_Click);
 			// 
-			// openFileToolStripMenuItem
+			// dataFileToolStripMenuItem
 			// 
-			this.openFileToolStripMenuItem.Name = "openFileToolStripMenuItem";
-			this.openFileToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-			this.openFileToolStripMenuItem.Text = "Open File...";
-			this.openFileToolStripMenuItem.Click += new System.EventHandler(this.OpenFileToolStripMenuItem_Click);
+			this.dataFileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.openDataFileToolStripMenuItem,
+			this.addDataFileToProjectToolStripMenuItem});
+			this.dataFileToolStripMenuItem.Name = "dataFileToolStripMenuItem";
+			this.dataFileToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+			this.dataFileToolStripMenuItem.Text = "Data File";
 			// 
-			// addToProjectToolStripMenuItem
+			// openDataFileToolStripMenuItem
 			// 
-			this.addToProjectToolStripMenuItem.Enabled = false;
-			this.addToProjectToolStripMenuItem.Name = "addToProjectToolStripMenuItem";
-			this.addToProjectToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-			this.addToProjectToolStripMenuItem.Text = "Add To Project...";
-			this.addToProjectToolStripMenuItem.Click += new System.EventHandler(this.AddToProjectToolStripMenuItem_Click);
+			this.openDataFileToolStripMenuItem.Name = "openDataFileToolStripMenuItem";
+			this.openDataFileToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
+			this.openDataFileToolStripMenuItem.Text = "Open...";
+			this.openDataFileToolStripMenuItem.Click += new System.EventHandler(this.OpenDataFileToolStripMenuItem_Click);
+			// 
+			// addDataFileToProjectToolStripMenuItem
+			// 
+			this.addDataFileToProjectToolStripMenuItem.Enabled = false;
+			this.addDataFileToProjectToolStripMenuItem.Name = "addDataFileToProjectToolStripMenuItem";
+			this.addDataFileToProjectToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
+			this.addDataFileToProjectToolStripMenuItem.Text = "Add To Project...";
+			this.addDataFileToProjectToolStripMenuItem.Click += new System.EventHandler(this.AddDataFileToProjectToolStripMenuItem_Click);
+			// 
+			// particlesFileToolStripMenuItem
+			// 
+			this.particlesFileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.openParticlesPCFileToolStripMenuItem,
+			this.openParticlesPSXFileToolStripMenuItem,
+			this.saveParticlesFileToolStripMenuItem});
+			this.particlesFileToolStripMenuItem.Name = "particlesFileToolStripMenuItem";
+			this.particlesFileToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+			this.particlesFileToolStripMenuItem.Text = "Particles File";
+			// 
+			// openParticlesPCFileToolStripMenuItem
+			// 
+			this.openParticlesPCFileToolStripMenuItem.Name = "openParticlesPCFileToolStripMenuItem";
+			this.openParticlesPCFileToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+			this.openParticlesPCFileToolStripMenuItem.Text = "Open PC...";
+			this.openParticlesPCFileToolStripMenuItem.Click += new System.EventHandler(this.OpenParticlesPCFileToolStripMenuItem_Click);
+			// 
+			// saveParticlesFileToolStripMenuItem
+			// 
+			this.saveParticlesFileToolStripMenuItem.Enabled = false;
+			this.saveParticlesFileToolStripMenuItem.Name = "saveParticlesFileToolStripMenuItem";
+			this.saveParticlesFileToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+			this.saveParticlesFileToolStripMenuItem.Text = "Save...";
+			this.saveParticlesFileToolStripMenuItem.Click += new System.EventHandler(this.SaveParticlesFileToolStripMenuItem_Click);
 			// 
 			// scriptedImportsToolStripMenuItem
 			// 
 			this.scriptedImportsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.importUndercityFeb04ToolStripMenuItem,
-            this.importUndercityFeb16ToolStripMenuItem,
-            this.importSmokestackToolStripMenuItem,
-            this.importRetreatToolStripMenuItem,
-            this.importOraclesCaveToolStripMenuItem,
-            this.importAllCutAreasToolStripMenuItem});
+			this.importUndercityFeb04ToolStripMenuItem,
+			this.importUndercityFeb16ToolStripMenuItem,
+			this.importSmokestackToolStripMenuItem,
+			this.importRetreatToolStripMenuItem,
+			this.importOraclesCaveToolStripMenuItem,
+			this.importAllCutAreasToolStripMenuItem});
 			this.scriptedImportsToolStripMenuItem.Enabled = false;
 			this.scriptedImportsToolStripMenuItem.Name = "scriptedImportsToolStripMenuItem";
 			this.scriptedImportsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
@@ -157,7 +199,7 @@
 			// 
 			// importUndercityFeb04ToolStripMenuItem
 			// 
-			this.importUndercityFeb04ToolStripMenuItem.Name = "importUndercityToolStripMenuItem";
+			this.importUndercityFeb04ToolStripMenuItem.Name = "importUndercityFeb04ToolStripMenuItem";
 			this.importUndercityFeb04ToolStripMenuItem.Size = new System.Drawing.Size(218, 22);
 			this.importUndercityFeb04ToolStripMenuItem.Text = "Import Undercity - Feb 04...";
 			this.importUndercityFeb04ToolStripMenuItem.Click += new System.EventHandler(this.ImportUndercityFeb04ToolStripMenuItem_Click);
@@ -216,8 +258,8 @@
 			// bulkTestingToolStripMenuItem
 			// 
 			this.bulkTestingToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.detailedExportToolStripMenuItem,
-            this.briefExportToolStripMenuItem});
+			this.detailedExportToolStripMenuItem,
+			this.briefExportToolStripMenuItem});
 			this.bulkTestingToolStripMenuItem.Name = "bulkTestingToolStripMenuItem";
 			this.bulkTestingToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.bulkTestingToolStripMenuItem.Text = "Bulk Testing";
@@ -259,10 +301,10 @@
 			treeListColumn4.HeaderFormat.BackColor = System.Drawing.SystemColors.ButtonFace;
 			treeListColumn4.Width = 50;
 			this.pcmFileTreeListView.Columns.AddRange(new TreeList.TreeListColumn[] {
-            treeListColumn1,
-            treeListColumn2,
-            treeListColumn3,
-            treeListColumn4});
+			treeListColumn1,
+			treeListColumn2,
+			treeListColumn3,
+			treeListColumn4});
 			this.pcmFileTreeListView.Cursor = System.Windows.Forms.Cursors.Arrow;
 			this.pcmFileTreeListView.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.pcmFileTreeListView.Images = null;
@@ -308,6 +350,7 @@
 			this.displayModeTabs.Controls.Add(this.pcmFileDataTab);
 			this.displayModeTabs.Controls.Add(this.scriptsTab);
 			this.displayModeTabs.Controls.Add(this.testResultsTab);
+			this.displayModeTabs.Controls.Add(this.particlesTab);
 			this.displayModeTabs.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.displayModeTabs.Location = new System.Drawing.Point(0, 24);
 			this.displayModeTabs.Margin = new System.Windows.Forms.Padding(0);
@@ -423,10 +466,28 @@
 			this.testResults.Size = new System.Drawing.Size(792, 400);
 			this.testResults.TabIndex = 0;
 			// 
+			// particlesTab
+			// 
+			this.particlesTab.Controls.Add(this.particlesPanel);
+			this.particlesTab.Location = new System.Drawing.Point(4, 22);
+			this.particlesTab.Name = "particlesTab";
+			this.particlesTab.Size = new System.Drawing.Size(792, 400);
+			this.particlesTab.TabIndex = 4;
+			this.particlesTab.Text = "Particles";
+			this.particlesTab.UseVisualStyleBackColor = true;
+			// 
+			// particlesPanel
+			// 
+			this.particlesPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.particlesPanel.Location = new System.Drawing.Point(0, 0);
+			this.particlesPanel.Name = "particlesPanel";
+			this.particlesPanel.Size = new System.Drawing.Size(792, 400);
+			this.particlesPanel.TabIndex = 0;
+			// 
 			// projectContextMenu
 			// 
 			this.projectContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.editPortalToolStripMenuItem});
+			this.editPortalToolStripMenuItem});
 			this.projectContextMenu.Name = "projectContextMenu";
 			this.projectContextMenu.Size = new System.Drawing.Size(138, 26);
 			// 
@@ -437,6 +498,13 @@
 			this.editPortalToolStripMenuItem.Size = new System.Drawing.Size(137, 22);
 			this.editPortalToolStripMenuItem.Text = "Edit Portal...";
 			this.editPortalToolStripMenuItem.Click += new System.EventHandler(this.EditPortalToolStripMenuItem_Click);
+			// 
+			// openParticlesPSXFileToolStripMenuItem
+			// 
+			this.openParticlesPSXFileToolStripMenuItem.Name = "openParticlesPSXFileToolStripMenuItem";
+			this.openParticlesPSXFileToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+			this.openParticlesPSXFileToolStripMenuItem.Text = "Open PSX...";
+			this.openParticlesPSXFileToolStripMenuItem.Click += new System.EventHandler(this.OpenParticlesPSXFileToolStripMenuItem_Click);
 			// 
 			// MainForm
 			// 
@@ -470,6 +538,7 @@
 			this.scriptsTab.PerformLayout();
 			this.testResultsTab.ResumeLayout(false);
 			this.testResultsTab.PerformLayout();
+			this.particlesTab.ResumeLayout(false);
 			this.projectContextMenu.ResumeLayout(false);
 			this.ResumeLayout(false);
 			this.PerformLayout();
@@ -480,7 +549,6 @@
 
 		private System.Windows.Forms.MenuStrip _mainMenu;
 		private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem openFileToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem testExportToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem bulkTestingToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
@@ -495,7 +563,6 @@
 		private System.Windows.Forms.TextBox testResults;
 		private System.Windows.Forms.ToolStripMenuItem detailedExportToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem briefExportToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem addToProjectToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem newProjectToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem openProjectToolStripMenuItem;
 		private System.Windows.Forms.TabPage projectTab;
@@ -505,13 +572,22 @@
 		private System.Windows.Forms.TextBox projectTextBox;
 		private System.Windows.Forms.ContextMenuStrip projectContextMenu;
 		private System.Windows.Forms.ToolStripMenuItem editPortalToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem scriptedImportsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem importUndercityFeb04ToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem importSmokestackToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem importRetreatToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem scriptedImportsToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem importUndercityFeb04ToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem importSmokestackToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem importRetreatToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem importOraclesCaveToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem importAllCutAreasToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem importUndercityFeb16ToolStripMenuItem;
+		private System.Windows.Forms.TabPage particlesTab;
+		private ParticlePanels.MainParticlesPanel particlesPanel;
+		private System.Windows.Forms.ToolStripMenuItem dataFileToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem particlesFileToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem openDataFileToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem addDataFileToProjectToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem openParticlesPCFileToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem saveParticlesFileToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem openParticlesPSXFileToolStripMenuItem;
 	}
 }
 

--- a/Recombobulator/MainForm.cs
+++ b/Recombobulator/MainForm.cs
@@ -24,7 +24,7 @@ namespace Recombobulator
 			InitializeComponent();
 		}
 
-		private void OpenFileToolStripMenuItem_Click(object sender, EventArgs e)
+		private void OpenDataFileToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			OpenFileDialog dialog = new OpenFileDialog
 			{
@@ -85,7 +85,7 @@ namespace Recombobulator
 					_fileLoaded = true;
 
 					testExportToolStripMenuItem.Enabled = _fileLoaded;
-					addToProjectToolStripMenuItem.Enabled = (_fileLoaded && _repository != null);
+					addDataFileToProjectToolStripMenuItem.Enabled = (_fileLoaded && _repository != null);
 				}
 				catch (Exception ex)
 				{
@@ -115,7 +115,7 @@ namespace Recombobulator
 			}
 		}
 
-		private void AddToProjectToolStripMenuItem_Click(object sender, EventArgs e)
+		private void AddDataFileToProjectToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			string fileName = Path.GetFileNameWithoutExtension(_file._FilePath);
 
@@ -332,8 +332,8 @@ namespace Recombobulator
 			_progressWindow.ShowInTaskbar = false;
 			this.Enabled = false;
 
-			addToProjectToolStripMenuItem.Enabled = (_fileLoaded && _repository != null);
-			compileProjectToolStripMenuItem.Enabled = (_repository != null);
+			addDataFileToProjectToolStripMenuItem.Enabled = (_fileLoaded && _repository != null);
+            compileProjectToolStripMenuItem.Enabled = (_repository != null);
 			scriptedImportsToolStripMenuItem.Enabled = (_repository != null);
 			editPortalToolStripMenuItem.Enabled = false;
 
@@ -342,7 +342,7 @@ namespace Recombobulator
 
 		private void EndUnpacking()
 		{
-			addToProjectToolStripMenuItem.Enabled = (_fileLoaded && _repository != null);
+			addDataFileToProjectToolStripMenuItem.Enabled = (_fileLoaded && _repository != null);
 			compileProjectToolStripMenuItem.Enabled = (_repository != null);
 			scriptedImportsToolStripMenuItem.Enabled = (_repository != null);
 			editPortalToolStripMenuItem.Enabled = false;
@@ -617,7 +617,7 @@ namespace Recombobulator
 			Properties.Settings.Default.RecentFolder = folderDialog.SelectedPath;
 			Properties.Settings.Default.Save();
 
-			addToProjectToolStripMenuItem.Enabled = (_fileLoaded && _repository != null);
+			addDataFileToProjectToolStripMenuItem.Enabled = (_fileLoaded && _repository != null);
 			compileProjectToolStripMenuItem.Enabled = (_repository != null);
 			scriptedImportsToolStripMenuItem.Enabled = (_repository != null);
 			editPortalToolStripMenuItem.Enabled = false;
@@ -627,7 +627,7 @@ namespace Recombobulator
 			{
 				_repository = repository;
 
-				addToProjectToolStripMenuItem.Enabled = (_fileLoaded && _repository != null);
+				addDataFileToProjectToolStripMenuItem.Enabled = (_fileLoaded && _repository != null);
 				compileProjectToolStripMenuItem.Enabled = (_repository != null);
 				scriptedImportsToolStripMenuItem.Enabled = (_repository != null);
 				editPortalToolStripMenuItem.Enabled = false;
@@ -1704,6 +1704,90 @@ namespace Recombobulator
 			#endregion
 
 			DoScriptedImport(dialog.SelectedPath, importScript);
+		}
+
+		private void OpenParticlesPCFileToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			OpenFileDialog dialog = new OpenFileDialog
+			{
+				CheckFileExists = true,
+				CheckPathExists = true,
+				Filter =
+					"Soul Reaver Files|*.pcm;*.drm|" +
+					"All Files (*.*)|*.*",
+				DefaultExt = "pcm",
+				FilterIndex = 1
+			};
+
+			if (dialog.ShowDialog() == DialogResult.OK)
+			{
+				try
+				{
+					//string filePath = _repository.MakeObjectFilePath("particle", true);
+					particlesPanel.Open(dialog.FileName, dialog.FileName);
+				}
+				catch (Exception ex)
+				{
+
+				}
+
+				displayModeTabs.SelectedTab = particlesTab;
+				saveParticlesFileToolStripMenuItem.Enabled = true;
+			}
+		}
+
+		private void OpenParticlesPSXFileToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			OpenFileDialog dialog = new OpenFileDialog
+			{
+				CheckFileExists = true,
+				CheckPathExists = true,
+				Filter =
+					"Soul Reaver Files|*.pcm;*.drm|" +
+					"All Files (*.*)|*.*",
+				DefaultExt = "pcm",
+				FilterIndex = 1
+			};
+
+			if (dialog.ShowDialog() == DialogResult.OK)
+			{
+				try
+				{
+					//string filePath = _repository.MakeObjectFilePath("particle", true);
+					particlesPanel.Open(dialog.FileName, dialog.FileName);
+				}
+				catch (Exception ex)
+				{
+
+				}
+
+				displayModeTabs.SelectedTab = particlesTab;
+				saveParticlesFileToolStripMenuItem.Enabled = true;
+			}
+		}
+
+		private void SaveParticlesFileToolStripMenuItem_Click(object sender, System.EventArgs e)
+		{
+			SaveFileDialog dialog = new SaveFileDialog
+			{
+				CheckFileExists = true,
+				CheckPathExists = true,
+				Filter = "Soul Reaver Files|*.pcm;*.drm",
+				DefaultExt = "pcm",
+				FilterIndex = 1
+			};
+
+			if (dialog.ShowDialog() == DialogResult.OK)
+			{
+				try
+				{
+					particlesPanel.Save(dialog.FileName);
+				}
+				catch (Exception ex)
+				{
+
+				}
+			}
 		}
 	}
 }

--- a/Recombobulator/ParticlePanels/EditBlastRingsPanel.Designer.cs
+++ b/Recombobulator/ParticlePanels/EditBlastRingsPanel.Designer.cs
@@ -1,0 +1,120 @@
+﻿namespace Recombobulator.ParticlePanels
+{
+    partial class EditBlastRingsPanel
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+			this.endColorBox = new System.Windows.Forms.PictureBox();
+			this.startColorBox = new System.Windows.Forms.PictureBox();
+			this.backPamel.SuspendLayout();
+			this.particlesPanel.SuspendLayout();
+			this.toolBoxPanel.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.endColorBox)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.startColorBox)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// particlesPanel
+			// 
+			this.particlesPanel.Controls.Add(this.endColorBox);
+			this.particlesPanel.Controls.Add(this.startColorBox);
+			// 
+			// selectionLabel
+			// 
+			this.selectionLabel.Size = new System.Drawing.Size(92, 13);
+			this.selectionLabel.Text = "Current Blast Ring";
+			// 
+			// pasteButton
+			// 
+			this.pasteButton.Click += new System.EventHandler(this.pasteButton_Click);
+			// 
+			// selectionComboBox
+			// 
+			this.selectionComboBox.SelectedIndexChanged += new System.EventHandler(this.selectionComboBox_SelectedIndexChanged);
+			// 
+			// copyButton
+			// 
+			this.copyButton.Click += new System.EventHandler(this.copyButton_Click);
+			// 
+			// insertButton
+			// 
+			this.insertButton.Click += new System.EventHandler(this.insertButton_Click);
+			// 
+			// removeButton
+			// 
+			this.removeButton.Click += new System.EventHandler(this.removeButton_Click);
+			// 
+			// resetButton
+			// 
+			this.resetButton.Click += new System.EventHandler(this.resetButton_Click);
+			// 
+			// addButton
+			// 
+			this.addButton.Click += new System.EventHandler(this.addButton_Click);
+			// 
+			// endColorBox
+			// 
+			this.endColorBox.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+			this.endColorBox.Location = new System.Drawing.Point(165, 605);
+			this.endColorBox.Margin = new System.Windows.Forms.Padding(0);
+			this.endColorBox.Name = "endColorBox";
+			this.endColorBox.Size = new System.Drawing.Size(50, 50);
+			this.endColorBox.TabIndex = 6;
+			this.endColorBox.TabStop = false;
+			this.endColorBox.Visible = false;
+			// 
+			// startColorBox
+			// 
+			this.startColorBox.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+			this.startColorBox.Location = new System.Drawing.Point(95, 605);
+			this.startColorBox.Margin = new System.Windows.Forms.Padding(0);
+			this.startColorBox.Name = "startColorBox";
+			this.startColorBox.Size = new System.Drawing.Size(50, 50);
+			this.startColorBox.TabIndex = 5;
+			this.startColorBox.TabStop = false;
+			this.startColorBox.Visible = false;
+			// 
+			// EditBlastRingsPanel
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.Name = "EditBlastRingsPanel";
+			this.backPamel.ResumeLayout(false);
+			this.particlesPanel.ResumeLayout(false);
+			this.toolBoxPanel.ResumeLayout(false);
+			this.toolBoxPanel.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.endColorBox)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.startColorBox)).EndInit();
+			this.ResumeLayout(false);
+
+        }
+
+		#endregion
+
+		private System.Windows.Forms.PictureBox endColorBox;
+		private System.Windows.Forms.PictureBox startColorBox;
+	}
+}

--- a/Recombobulator/ParticlePanels/EditBlastRingsPanel.cs
+++ b/Recombobulator/ParticlePanels/EditBlastRingsPanel.cs
@@ -1,0 +1,243 @@
+﻿using Recombobulator.SR1Structures;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+using System;
+using System.Globalization;
+
+namespace Recombobulator.ParticlePanels
+{
+    public partial class EditBlastRingsPanel : EditPanelBase
+    {
+        SR1_StructureSeries<GenericBlastRingParams> _blastRingsList = null;
+        SR1_StructureSeries<GenericBlastRingParams> _blastRingsListBackup = null;
+        GenericBlastRingParams _copiedBlastRingParams = new GenericBlastRingParams();
+
+        public EditBlastRingsPanel()
+        {
+            InitializeComponent();
+        }
+
+        public void Open(object blastRingsList, object blastRingsListBackup = null)
+        {
+            _blastRingsList = (SR1_StructureSeries<GenericBlastRingParams>)blastRingsList;
+            _blastRingsListBackup = (SR1_StructureSeries<GenericBlastRingParams>)blastRingsListBackup;
+
+            selectionComboBox.SelectedIndex = -1;
+            selectionComboBox.Items.Clear();
+            for (int i = 0; i < _blastRingsList.Count; i++)
+            {
+                selectionComboBox.Items.Add("blastRing-" + i.ToString());
+            }
+
+            selectionComboBox.SelectedIndex = 0;
+        }
+
+        private void startColor_TextChanged(object sender, EventArgs e)
+        {
+            int startColor = 0;
+
+            foreach (Control control in fieldsPanel.Controls)
+            {
+                if (control.Name == "startColor")
+				{
+					int.TryParse(control.Text, NumberStyles.HexNumber, NumberFormatInfo.CurrentInfo, out startColor);
+					startColor |= unchecked((int)0xFF000000);
+				}
+            }
+
+            startColorBox.BackColor = Color.FromArgb(startColor);
+        }
+
+        private void endColor_TextChanged(object sender, EventArgs e)
+		{
+			int endColor = 0;
+
+			foreach (Control control in fieldsPanel.Controls)
+			{
+				if (control.Name == "endColor")
+				{
+                    int.TryParse(control.Text, NumberStyles.HexNumber, NumberFormatInfo.CurrentInfo, out endColor);
+                    endColor |= unchecked((int)0xFF000000);
+				}
+			}
+
+			endColorBox.BackColor = Color.FromArgb(endColor);
+		}
+
+		private void selectionComboBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			int newIndex = selectionComboBox.SelectedIndex;
+
+			insertButton.Enabled = false;
+			removeButton.Enabled = false;
+			resetButton.Enabled = false;
+			addButton.Enabled = false;
+			copyButton.Enabled = false;
+			pasteButton.Enabled = false;
+
+			startColorBox.Visible = false;
+			endColorBox.Visible = false;
+
+			fieldsPanel.Controls.Clear();
+			fieldsPanel.RowStyles.Clear();
+
+			if (newIndex < 0)
+			{
+				return;
+			}
+
+			addButton.Enabled = true;
+			copyButton.Enabled = true;
+			pasteButton.Enabled = true;
+
+			if (_blastRingsListBackup != null)
+			{
+				if (newIndex < _blastRingsListBackup.Count)
+				{
+					insertButton.Enabled = false;
+					removeButton.Enabled = false;
+					resetButton.Enabled = true;
+				}
+				else
+				{
+					insertButton.Enabled = true;
+					removeButton.Enabled = true;
+					resetButton.Enabled = false;
+				}
+			}
+			else
+			{
+				insertButton.Enabled = true;
+				removeButton.Enabled = true;
+				resetButton.Enabled = false;
+			}
+
+			startColorBox.Visible = true;
+			endColorBox.Visible = true;
+
+			List<SR1_Structure> membersRead = _blastRingsList[newIndex].MembersRead;
+			fieldsPanel.RowCount = membersRead.Count;
+
+			int row = 0;
+			int startColor = 0;
+			int endColor = 0;
+			foreach (SR1_Structure structure in membersRead)
+			{
+				TextBox valueTextBox = AddField(structure, "", ref row);
+
+				if (structure.Name == "startColor")
+				{
+					startColor = ((SR1_Primative<int>)structure).Value;
+					valueTextBox.TextChanged += startColor_TextChanged;
+				}
+
+				if (structure.Name == "endColor")
+				{
+					endColor = ((SR1_Primative<int>)structure).Value;
+					valueTextBox.TextChanged += endColor_TextChanged;
+				}
+			}
+
+			startColor |= unchecked((int)0xFF000000);
+			endColor |= unchecked((int)0xFF000000);
+
+			startColorBox.BackColor = Color.FromArgb(startColor);
+			endColorBox.BackColor = Color.FromArgb(endColor);
+
+			fieldsPanel.Visible = true;
+			fieldsPanel.Enabled = true;
+		}
+
+		private void addButton_Click(object sender, EventArgs e)
+        {
+            _blastRingsList.Add(new GenericBlastRingParams());
+            selectionComboBox.SelectedIndex = _blastRingsList.Count - 1;
+        }
+
+        private void insertButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (currentIndex < 0)
+            {
+                return;
+            }
+
+            currentIndex = Math.Min(currentIndex, _blastRingsList.Count);
+
+            _blastRingsList.InsertAt(currentIndex, new GenericBlastRingParams());
+            selectionComboBox.SelectedIndex = -1;
+            selectionComboBox.SelectedIndex = currentIndex;
+        }
+
+        private void removeButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (currentIndex < 0 || currentIndex >= selectionComboBox.Items.Count)
+            {
+                return;
+            }
+
+            _blastRingsList.RemoveAt(currentIndex);
+            selectionComboBox.SelectedIndex = -1;
+
+            if (selectionComboBox.Items.Count > 0)
+            {
+                currentIndex = Math.Min(currentIndex, _blastRingsList.Count - 1);
+                selectionComboBox.SelectedIndex = currentIndex;
+            }
+        }
+
+        private void copyButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (currentIndex < 0 ||
+                currentIndex >= _blastRingsList.Count)
+            {
+                return;
+            }
+
+            GenericBlastRingParams.Copy(_copiedBlastRingParams, (GenericBlastRingParams)_blastRingsList[currentIndex]);
+        }
+
+        private void pasteButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (currentIndex < 0 ||
+                currentIndex >= _blastRingsList.Count)
+            {
+                return;
+            }
+
+            GenericBlastRingParams.Copy((GenericBlastRingParams)_blastRingsList[currentIndex], _copiedBlastRingParams);
+
+            selectionComboBox.SelectedIndex = -1;
+            selectionComboBox.SelectedIndex = currentIndex;
+        }
+
+        private void resetButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (_blastRingsListBackup == null ||
+                currentIndex < 0 ||
+                currentIndex >= _blastRingsList.Count ||
+                currentIndex >= _blastRingsListBackup.Count)
+            {
+                return;
+            }
+
+            GenericBlastRingParams.Copy(
+                (GenericBlastRingParams)_blastRingsList[currentIndex],
+                (GenericBlastRingParams)_blastRingsListBackup[currentIndex]
+            );
+
+            selectionComboBox.SelectedIndex = -1;
+            selectionComboBox.SelectedIndex = currentIndex;
+        }
+    }
+}

--- a/Recombobulator/ParticlePanels/EditBlastRingsPanel.resx
+++ b/Recombobulator/ParticlePanels/EditBlastRingsPanel.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Recombobulator/ParticlePanels/EditFlashesPanel.Designer.cs
+++ b/Recombobulator/ParticlePanels/EditFlashesPanel.Designer.cs
@@ -1,0 +1,103 @@
+﻿namespace Recombobulator.ParticlePanels
+{
+    partial class EditFlashesPanel
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+			this.colorBox = new System.Windows.Forms.PictureBox();
+			this.backPamel.SuspendLayout();
+			this.particlesPanel.SuspendLayout();
+			this.toolBoxPanel.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.colorBox)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// particlesPanel
+			// 
+			this.particlesPanel.Controls.Add(this.colorBox);
+			// 
+			// selectionLabel
+			// 
+			this.selectionLabel.Size = new System.Drawing.Size(69, 13);
+			this.selectionLabel.Text = "Current Flash";
+			// 
+			// pasteButton
+			// 
+			this.pasteButton.Click += new System.EventHandler(this.pasteButton_Click);
+			// 
+			// selectionComboBox
+			// 
+			this.selectionComboBox.SelectedIndexChanged += new System.EventHandler(this.selectionComboBox_SelectedIndexChanged);
+			// 
+			// copyButton
+			// 
+			this.copyButton.Click += new System.EventHandler(this.copyButton_Click);
+			// 
+			// insertButton
+			// 
+			this.insertButton.Click += new System.EventHandler(this.insertButton_Click);
+			// 
+			// removeButton
+			// 
+			this.removeButton.Click += new System.EventHandler(this.removeButton_Click);
+			// 
+			// resetButton
+			// 
+			this.resetButton.Click += new System.EventHandler(this.resetButton_Click);
+			// 
+			// addButton
+			// 
+			this.addButton.Click += new System.EventHandler(this.addButton_Click);
+			// 
+			// colorBox
+			// 
+			this.colorBox.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+			this.colorBox.Location = new System.Drawing.Point(95, 65);
+			this.colorBox.Margin = new System.Windows.Forms.Padding(0);
+			this.colorBox.Name = "colorBox";
+			this.colorBox.Size = new System.Drawing.Size(50, 50);
+			this.colorBox.TabIndex = 5;
+			this.colorBox.TabStop = false;
+			this.colorBox.Visible = false;
+			// 
+			// EditFlashesPanel
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.Name = "EditFlashesPanel";
+			this.backPamel.ResumeLayout(false);
+			this.particlesPanel.ResumeLayout(false);
+			this.toolBoxPanel.ResumeLayout(false);
+			this.toolBoxPanel.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.colorBox)).EndInit();
+			this.ResumeLayout(false);
+
+        }
+
+		#endregion
+		private System.Windows.Forms.PictureBox colorBox;
+	}
+}

--- a/Recombobulator/ParticlePanels/EditFlashesPanel.cs
+++ b/Recombobulator/ParticlePanels/EditFlashesPanel.cs
@@ -1,0 +1,216 @@
+﻿using Recombobulator.SR1Structures;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+using System;
+using System.Globalization;
+
+namespace Recombobulator.ParticlePanels
+{
+	public partial class EditFlashesPanel : EditPanelBase
+	{
+		SR1_StructureSeries<GenericFlashParams> _flashesList = null;
+		SR1_StructureSeries<GenericFlashParams> _flashesListBackup = null;
+		GenericFlashParams _copiedFlashParams = new GenericFlashParams();
+
+		public EditFlashesPanel()
+		{
+			InitializeComponent();
+		}
+
+		public void Open(object lightningsList, object lightningsListBackup = null)
+		{
+			_flashesList = (SR1_StructureSeries<GenericFlashParams>)lightningsList;
+			_flashesListBackup = (SR1_StructureSeries<GenericFlashParams>)lightningsListBackup;
+
+			selectionComboBox.SelectedIndex = -1;
+			selectionComboBox.Items.Clear();
+			for (int i = 0; i < _flashesList.Count; i++)
+			{
+				selectionComboBox.Items.Add("flash-" + i.ToString());
+			}
+
+			selectionComboBox.SelectedIndex = 0;
+		}
+
+		private void color_TextChanged(object sender, EventArgs e)
+		{
+			int color = 0;
+
+			foreach (Control control in fieldsPanel.Controls)
+			{
+				if (control.Name == "color")
+				{
+					int.TryParse(control.Text, NumberStyles.HexNumber, NumberFormatInfo.CurrentInfo, out color);
+					color |= unchecked((int)0xFF000000);
+				}
+			}
+
+			colorBox.BackColor = Color.FromArgb(color);
+		}
+
+		private void selectionComboBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			int newIndex = selectionComboBox.SelectedIndex;
+
+			insertButton.Enabled = false;
+			removeButton.Enabled = false;
+			resetButton.Enabled = false;
+			addButton.Enabled = false;
+			copyButton.Enabled = false;
+			pasteButton.Enabled = false;
+
+			colorBox.Visible = false;
+
+			fieldsPanel.Controls.Clear();
+			fieldsPanel.RowStyles.Clear();
+
+			if (newIndex < 0)
+			{
+				return;
+			}
+
+			addButton.Enabled = true;
+			copyButton.Enabled = true;
+			pasteButton.Enabled = true;
+
+			if (_flashesListBackup != null)
+			{
+				if (newIndex < _flashesListBackup.Count)
+				{
+					insertButton.Enabled = false;
+					removeButton.Enabled = false;
+					resetButton.Enabled = true;
+				}
+				else
+				{
+					insertButton.Enabled = true;
+					removeButton.Enabled = true;
+					resetButton.Enabled = false;
+				}
+			}
+			else
+			{
+				insertButton.Enabled = true;
+				removeButton.Enabled = true;
+				resetButton.Enabled = false;
+			}
+
+			colorBox.Visible = true;
+
+			List<SR1_Structure> membersRead = _flashesList[newIndex].MembersRead;
+			fieldsPanel.RowCount = membersRead.Count;
+
+			int row = 0;
+			int color = 0;
+			foreach (SR1_Structure structure in membersRead)
+			{
+				TextBox valueTextBox = AddField(structure, "", ref row);
+
+				if (structure.Name == "color")
+				{
+					color = ((SR1_Primative<int>)structure).Value;
+					valueTextBox.TextChanged += color_TextChanged;
+				}
+			}
+
+			color |= unchecked((int)0xFF000000);
+
+			colorBox.BackColor = Color.FromArgb(color);
+
+			fieldsPanel.Visible = true;
+			fieldsPanel.Enabled = true;
+		}
+
+		private void addButton_Click(object sender, EventArgs e)
+		{
+			_flashesList.Add(new GenericFlashParams());
+			selectionComboBox.SelectedIndex = _flashesList.Count - 1;
+		}
+
+		private void insertButton_Click(object sender, EventArgs e)
+		{
+			int currentIndex = selectionComboBox.SelectedIndex;
+
+			if (currentIndex < 0)
+			{
+				return;
+			}
+
+			currentIndex = Math.Min(currentIndex, _flashesList.Count);
+
+			_flashesList.InsertAt(currentIndex, new GenericFlashParams());
+			selectionComboBox.SelectedIndex = -1;
+			selectionComboBox.SelectedIndex = currentIndex;
+		}
+
+		private void removeButton_Click(object sender, EventArgs e)
+		{
+			int currentIndex = selectionComboBox.SelectedIndex;
+
+			if (currentIndex < 0 || currentIndex >= selectionComboBox.Items.Count)
+			{
+				return;
+			}
+
+			_flashesList.RemoveAt(currentIndex);
+			selectionComboBox.SelectedIndex = -1;
+
+			if (selectionComboBox.Items.Count > 0)
+			{
+				currentIndex = Math.Min(currentIndex, _flashesList.Count - 1);
+				selectionComboBox.SelectedIndex = currentIndex;
+			}
+		}
+
+		private void copyButton_Click(object sender, EventArgs e)
+		{
+			int currentIndex = selectionComboBox.SelectedIndex;
+
+			if (currentIndex < 0 ||
+				currentIndex >= _flashesList.Count)
+			{
+				return;
+			}
+
+			GenericFlashParams.Copy(_copiedFlashParams, (GenericFlashParams)_flashesList[currentIndex]);
+		}
+
+		private void pasteButton_Click(object sender, EventArgs e)
+		{
+			int currentIndex = selectionComboBox.SelectedIndex;
+
+			if (currentIndex < 0 ||
+				currentIndex >= _flashesList.Count)
+			{
+				return;
+			}
+
+			GenericFlashParams.Copy((GenericFlashParams)_flashesList[currentIndex], _copiedFlashParams);
+
+			selectionComboBox.SelectedIndex = -1;
+			selectionComboBox.SelectedIndex = currentIndex;
+		}
+
+		private void resetButton_Click(object sender, EventArgs e)
+		{
+			int currentIndex = selectionComboBox.SelectedIndex;
+
+			if (_flashesListBackup == null ||
+				currentIndex < 0 ||
+				currentIndex >= _flashesList.Count ||
+				currentIndex >= _flashesListBackup.Count)
+			{
+				return;
+			}
+
+			GenericFlashParams.Copy(
+				(GenericFlashParams)_flashesList[currentIndex],
+				(GenericFlashParams)_flashesListBackup[currentIndex]
+			);
+
+			selectionComboBox.SelectedIndex = -1;
+			selectionComboBox.SelectedIndex = currentIndex;
+		}
+	}
+}

--- a/Recombobulator/ParticlePanels/EditFlashesPanel.resx
+++ b/Recombobulator/ParticlePanels/EditFlashesPanel.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Recombobulator/ParticlePanels/EditGlowsPanel.Designer.cs
+++ b/Recombobulator/ParticlePanels/EditGlowsPanel.Designer.cs
@@ -1,0 +1,82 @@
+﻿namespace Recombobulator.ParticlePanels
+{
+    partial class EditGlowsPanel
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+			this.backPamel.SuspendLayout();
+			this.toolBoxPanel.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// selectionLabel
+			// 
+			this.selectionLabel.Size = new System.Drawing.Size(68, 13);
+			this.selectionLabel.Text = "Current Glow";
+			// 
+			// pasteButton
+			// 
+			this.pasteButton.Click += new System.EventHandler(this.pasteButton_Click);
+			// 
+			// selectionComboBox
+			// 
+			this.selectionComboBox.SelectedIndexChanged += new System.EventHandler(this.selectionComboBox_SelectedIndexChanged);
+			// 
+			// copyButton
+			// 
+			this.copyButton.Click += new System.EventHandler(this.copyButton_Click);
+			// 
+			// insertButton
+			// 
+			this.insertButton.Click += new System.EventHandler(this.insertButton_Click);
+			// 
+			// removeButton
+			// 
+			this.removeButton.Click += new System.EventHandler(this.removeButton_Click);
+			// 
+			// resetButton
+			// 
+			this.resetButton.Click += new System.EventHandler(this.resetButton_Click);
+			// 
+			// addButton
+			// 
+			this.addButton.Click += new System.EventHandler(this.addButton_Click);
+			// 
+			// EditGlowsPanel
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.Name = "EditGlowsPanel";
+			this.backPamel.ResumeLayout(false);
+			this.toolBoxPanel.ResumeLayout(false);
+			this.toolBoxPanel.PerformLayout();
+			this.ResumeLayout(false);
+
+        }
+
+		#endregion
+	}
+}

--- a/Recombobulator/ParticlePanels/EditGlowsPanel.cs
+++ b/Recombobulator/ParticlePanels/EditGlowsPanel.cs
@@ -1,0 +1,184 @@
+﻿using Recombobulator.SR1Structures;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+using System;
+
+namespace Recombobulator.ParticlePanels
+{
+    public partial class EditGlowsPanel : EditPanelBase
+    {
+        SR1_StructureSeries<GenericGlowParams> _glowsList = null;
+        SR1_StructureSeries<GenericGlowParams> _glowsListBackup = null;
+        GenericGlowParams _copiedGlowParams = new GenericGlowParams();
+
+        public EditGlowsPanel()
+        {
+            InitializeComponent();
+        }
+
+        public void Open(object glowsList, object glowsListBackup = null)
+        {
+            _glowsList = (SR1_StructureSeries<GenericGlowParams>)glowsList;
+            _glowsListBackup = (SR1_StructureSeries<GenericGlowParams>)glowsListBackup;
+
+            selectionComboBox.SelectedIndex = -1;
+            selectionComboBox.Items.Clear();
+            for (int i = 0; i < _glowsList.Count; i++)
+            {
+                selectionComboBox.Items.Add("glow-" + i.ToString());
+            }
+
+            selectionComboBox.SelectedIndex = 0;
+        }
+
+		private void selectionComboBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			int newIndex = selectionComboBox.SelectedIndex;
+
+			insertButton.Enabled = false;
+			removeButton.Enabled = false;
+			resetButton.Enabled = false;
+			addButton.Enabled = false;
+			copyButton.Enabled = false;
+			pasteButton.Enabled = false;
+
+			fieldsPanel.Controls.Clear();
+			fieldsPanel.RowStyles.Clear();
+
+			if (newIndex < 0)
+			{
+				return;
+			}
+
+			addButton.Enabled = true;
+			copyButton.Enabled = true;
+			pasteButton.Enabled = true;
+
+			if (_glowsListBackup != null)
+			{
+				if (newIndex < _glowsListBackup.Count)
+				{
+					insertButton.Enabled = false;
+					removeButton.Enabled = false;
+					resetButton.Enabled = true;
+				}
+				else
+				{
+					insertButton.Enabled = true;
+					removeButton.Enabled = true;
+					resetButton.Enabled = false;
+				}
+			}
+			else
+			{
+				insertButton.Enabled = true;
+				removeButton.Enabled = true;
+				resetButton.Enabled = false;
+			}
+
+			List<SR1_Structure> membersRead = _glowsList[newIndex].MembersRead;
+			fieldsPanel.RowCount = membersRead.Count;
+
+			int row = 0;
+			foreach (SR1_Structure structure in membersRead)
+			{
+				TextBox valueTextBox = AddField(structure, "", ref row);
+			}
+
+			fieldsPanel.Visible = true;
+			fieldsPanel.Enabled = true;
+		}
+
+		private void addButton_Click(object sender, EventArgs e)
+        {
+            _glowsList.Add(new GenericGlowParams());
+            selectionComboBox.SelectedIndex = _glowsList.Count - 1;
+        }
+
+        private void insertButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (currentIndex < 0)
+            {
+                return;
+            }
+
+            currentIndex = Math.Min(currentIndex, _glowsList.Count);
+
+            _glowsList.InsertAt(currentIndex, new GenericGlowParams());
+            selectionComboBox.SelectedIndex = -1;
+            selectionComboBox.SelectedIndex = currentIndex;
+        }
+
+        private void removeButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (currentIndex < 0 || currentIndex >= selectionComboBox.Items.Count)
+            {
+                return;
+            }
+
+            _glowsList.RemoveAt(currentIndex);
+            selectionComboBox.SelectedIndex = -1;
+
+            if (selectionComboBox.Items.Count > 0)
+            {
+                currentIndex = Math.Min(currentIndex, _glowsList.Count - 1);
+                selectionComboBox.SelectedIndex = currentIndex;
+            }
+        }
+
+        private void copyButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (currentIndex < 0 ||
+                currentIndex >= _glowsList.Count)
+            {
+                return;
+            }
+
+            GenericGlowParams.Copy(_copiedGlowParams, (GenericGlowParams)_glowsList[currentIndex]);
+        }
+
+        private void pasteButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (currentIndex < 0 ||
+                currentIndex >= _glowsList.Count)
+            {
+                return;
+            }
+
+            GenericGlowParams.Copy((GenericGlowParams)_glowsList[currentIndex], _copiedGlowParams);
+
+            selectionComboBox.SelectedIndex = -1;
+            selectionComboBox.SelectedIndex = currentIndex;
+        }
+
+        private void resetButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (_glowsListBackup == null ||
+                currentIndex < 0 ||
+                currentIndex >= _glowsList.Count ||
+                currentIndex >= _glowsListBackup.Count)
+            {
+                return;
+            }
+
+            GenericGlowParams.Copy(
+                (GenericGlowParams)_glowsList[currentIndex],
+                (GenericGlowParams)_glowsListBackup[currentIndex]
+            );
+
+            selectionComboBox.SelectedIndex = -1;
+            selectionComboBox.SelectedIndex = currentIndex;
+        }
+    }
+}

--- a/Recombobulator/ParticlePanels/EditGlowsPanel.resx
+++ b/Recombobulator/ParticlePanels/EditGlowsPanel.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Recombobulator/ParticlePanels/EditLightningsPanel.Designer.cs
+++ b/Recombobulator/ParticlePanels/EditLightningsPanel.Designer.cs
@@ -1,0 +1,120 @@
+﻿namespace Recombobulator.ParticlePanels
+{
+    partial class EditLightningsPanel
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+			this.glowColorBox = new System.Windows.Forms.PictureBox();
+			this.colorBox = new System.Windows.Forms.PictureBox();
+			this.backPamel.SuspendLayout();
+			this.particlesPanel.SuspendLayout();
+			this.toolBoxPanel.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.glowColorBox)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.colorBox)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// particlesPanel
+			// 
+			this.particlesPanel.Controls.Add(this.glowColorBox);
+			this.particlesPanel.Controls.Add(this.colorBox);
+			// 
+			// selectionLabel
+			// 
+			this.selectionLabel.Size = new System.Drawing.Size(87, 13);
+			this.selectionLabel.Text = "Current Lightning";
+			// 
+			// pasteButton
+			// 
+			this.pasteButton.Click += new System.EventHandler(this.pasteButton_Click);
+			// 
+			// selectionComboBox
+			// 
+			this.selectionComboBox.SelectedIndexChanged += new System.EventHandler(this.selectionComboBox_SelectedIndexChanged);
+			// 
+			// copyButton
+			// 
+			this.copyButton.Click += new System.EventHandler(this.copyButton_Click);
+			// 
+			// insertButton
+			// 
+			this.insertButton.Click += new System.EventHandler(this.insertButton_Click);
+			// 
+			// removeButton
+			// 
+			this.removeButton.Click += new System.EventHandler(this.removeButton_Click);
+			// 
+			// resetButton
+			// 
+			this.resetButton.Click += new System.EventHandler(this.resetButton_Click);
+			// 
+			// addButton
+			// 
+			this.addButton.Click += new System.EventHandler(this.addButton_Click);
+			// 
+			// endColorBox
+			// 
+			this.glowColorBox.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+			this.glowColorBox.Location = new System.Drawing.Point(165, 575);
+			this.glowColorBox.Margin = new System.Windows.Forms.Padding(0);
+			this.glowColorBox.Name = "endColorBox";
+			this.glowColorBox.Size = new System.Drawing.Size(50, 50);
+			this.glowColorBox.TabIndex = 6;
+			this.glowColorBox.TabStop = false;
+			this.glowColorBox.Visible = false;
+			// 
+			// startColorBox
+			// 
+			this.colorBox.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+			this.colorBox.Location = new System.Drawing.Point(95, 575);
+			this.colorBox.Margin = new System.Windows.Forms.Padding(0);
+			this.colorBox.Name = "startColorBox";
+			this.colorBox.Size = new System.Drawing.Size(50, 50);
+			this.colorBox.TabIndex = 5;
+			this.colorBox.TabStop = false;
+			this.colorBox.Visible = false;
+			// 
+			// EditLightningsPanel
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.Name = "EditLightningsPanel";
+			this.backPamel.ResumeLayout(false);
+			this.particlesPanel.ResumeLayout(false);
+			this.toolBoxPanel.ResumeLayout(false);
+			this.toolBoxPanel.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.glowColorBox)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.colorBox)).EndInit();
+			this.ResumeLayout(false);
+
+        }
+
+		#endregion
+
+		private System.Windows.Forms.PictureBox glowColorBox;
+		private System.Windows.Forms.PictureBox colorBox;
+	}
+}

--- a/Recombobulator/ParticlePanels/EditLightningsPanel.cs
+++ b/Recombobulator/ParticlePanels/EditLightningsPanel.cs
@@ -1,0 +1,243 @@
+﻿using Recombobulator.SR1Structures;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+using System;
+using System.Globalization;
+
+namespace Recombobulator.ParticlePanels
+{
+	public partial class EditLightningsPanel : EditPanelBase
+	{
+		SR1_StructureSeries<GenericLightningParams> _lightningsList = null;
+		SR1_StructureSeries<GenericLightningParams> _lightningsListBackup = null;
+		GenericLightningParams _copiedLightningParams = new GenericLightningParams();
+
+		public EditLightningsPanel()
+		{
+			InitializeComponent();
+		}
+
+		public void Open(object lightningsList, object lightningsListBackup = null)
+		{
+			_lightningsList = (SR1_StructureSeries<GenericLightningParams>)lightningsList;
+			_lightningsListBackup = (SR1_StructureSeries<GenericLightningParams>)lightningsListBackup;
+
+			selectionComboBox.SelectedIndex = -1;
+			selectionComboBox.Items.Clear();
+			for (int i = 0; i < _lightningsList.Count; i++)
+			{
+				selectionComboBox.Items.Add("lightning-" + i.ToString());
+			}
+
+			selectionComboBox.SelectedIndex = 0;
+		}
+
+		private void color_TextChanged(object sender, EventArgs e)
+		{
+			int color = 0;
+
+			foreach (Control control in fieldsPanel.Controls)
+			{
+				if (control.Name == "color")
+				{
+					int.TryParse(control.Text, NumberStyles.HexNumber, NumberFormatInfo.CurrentInfo, out color);
+					color |= unchecked((int)0xFF000000);
+				}
+			}
+
+			colorBox.BackColor = Color.FromArgb(color);
+		}
+
+		private void glowColor_TextChanged(object sender, EventArgs e)
+		{
+			int glow_color = 0;
+
+			foreach (Control control in fieldsPanel.Controls)
+			{
+				if (control.Name == "glow_color")
+				{
+					int.TryParse(control.Text, NumberStyles.HexNumber, NumberFormatInfo.CurrentInfo, out glow_color);
+					glow_color |= unchecked((int)0xFF000000);
+				}
+			}
+
+			glowColorBox.BackColor = Color.FromArgb(glow_color);
+		}
+
+		private void selectionComboBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			int newIndex = selectionComboBox.SelectedIndex;
+
+			insertButton.Enabled = false;
+			removeButton.Enabled = false;
+			resetButton.Enabled = false;
+			addButton.Enabled = false;
+			copyButton.Enabled = false;
+			pasteButton.Enabled = false;
+
+			colorBox.Visible = false;
+			glowColorBox.Visible = false;
+
+			fieldsPanel.Controls.Clear();
+			fieldsPanel.RowStyles.Clear();
+
+			if (newIndex < 0)
+			{
+				return;
+			}
+
+			addButton.Enabled = true;
+			copyButton.Enabled = true;
+			pasteButton.Enabled = true;
+
+			if (_lightningsListBackup != null)
+			{
+				if (newIndex < _lightningsListBackup.Count)
+				{
+					insertButton.Enabled = false;
+					removeButton.Enabled = false;
+					resetButton.Enabled = true;
+				}
+				else
+				{
+					insertButton.Enabled = true;
+					removeButton.Enabled = true;
+					resetButton.Enabled = false;
+				}
+			}
+			else
+			{
+				insertButton.Enabled = true;
+				removeButton.Enabled = true;
+				resetButton.Enabled = false;
+			}
+
+			colorBox.Visible = true;
+			glowColorBox.Visible = true;
+
+			List<SR1_Structure> membersRead = _lightningsList[newIndex].MembersRead;
+			fieldsPanel.RowCount = membersRead.Count;
+
+			int row = 0;
+			int color = 0;
+			int glow_color = 0;
+			foreach (SR1_Structure structure in membersRead)
+			{
+				TextBox valueTextBox = AddField(structure, "", ref row);
+
+				if (structure.Name == "color")
+				{
+					color = ((SR1_Primative<int>)structure).Value;
+					valueTextBox.TextChanged += color_TextChanged;
+				}
+
+				if (structure.Name == "glow_color")
+				{
+					glow_color = ((SR1_Primative<int>)structure).Value;
+					valueTextBox.TextChanged += glowColor_TextChanged;
+				}
+			}
+
+			color |= unchecked((int)0xFF000000);
+			glow_color |= unchecked((int)0xFF000000);
+
+			colorBox.BackColor = Color.FromArgb(color);
+			glowColorBox.BackColor = Color.FromArgb(glow_color);
+
+			fieldsPanel.Visible = true;
+			fieldsPanel.Enabled = true;
+		}
+
+		private void addButton_Click(object sender, EventArgs e)
+		{
+			_lightningsList.Add(new GenericLightningParams());
+			selectionComboBox.SelectedIndex = _lightningsList.Count - 1;
+		}
+
+		private void insertButton_Click(object sender, EventArgs e)
+		{
+			int currentIndex = selectionComboBox.SelectedIndex;
+
+			if (currentIndex < 0)
+			{
+				return;
+			}
+
+			currentIndex = Math.Min(currentIndex, _lightningsList.Count);
+
+			_lightningsList.InsertAt(currentIndex, new GenericLightningParams());
+			selectionComboBox.SelectedIndex = -1;
+			selectionComboBox.SelectedIndex = currentIndex;
+		}
+
+		private void removeButton_Click(object sender, EventArgs e)
+		{
+			int currentIndex = selectionComboBox.SelectedIndex;
+
+			if (currentIndex < 0 || currentIndex >= selectionComboBox.Items.Count)
+			{
+				return;
+			}
+
+			_lightningsList.RemoveAt(currentIndex);
+			selectionComboBox.SelectedIndex = -1;
+
+			if (selectionComboBox.Items.Count > 0)
+			{
+				currentIndex = Math.Min(currentIndex, _lightningsList.Count - 1);
+				selectionComboBox.SelectedIndex = currentIndex;
+			}
+		}
+
+		private void copyButton_Click(object sender, EventArgs e)
+		{
+			int currentIndex = selectionComboBox.SelectedIndex;
+
+			if (currentIndex < 0 ||
+				currentIndex >= _lightningsList.Count)
+			{
+				return;
+			}
+
+			GenericLightningParams.Copy(_copiedLightningParams, (GenericLightningParams)_lightningsList[currentIndex]);
+		}
+
+		private void pasteButton_Click(object sender, EventArgs e)
+		{
+			int currentIndex = selectionComboBox.SelectedIndex;
+
+			if (currentIndex < 0 ||
+				currentIndex >= _lightningsList.Count)
+			{
+				return;
+			}
+
+			GenericLightningParams.Copy((GenericLightningParams)_lightningsList[currentIndex], _copiedLightningParams);
+
+			selectionComboBox.SelectedIndex = -1;
+			selectionComboBox.SelectedIndex = currentIndex;
+		}
+
+		private void resetButton_Click(object sender, EventArgs e)
+		{
+			int currentIndex = selectionComboBox.SelectedIndex;
+
+			if (_lightningsListBackup == null ||
+				currentIndex < 0 ||
+				currentIndex >= _lightningsList.Count ||
+				currentIndex >= _lightningsListBackup.Count)
+			{
+				return;
+			}
+
+			GenericLightningParams.Copy(
+				(GenericLightningParams)_lightningsList[currentIndex],
+				(GenericLightningParams)_lightningsListBackup[currentIndex]
+			);
+
+			selectionComboBox.SelectedIndex = -1;
+			selectionComboBox.SelectedIndex = currentIndex;
+		}
+	}
+}

--- a/Recombobulator/ParticlePanels/EditLightningsPanel.resx
+++ b/Recombobulator/ParticlePanels/EditLightningsPanel.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Recombobulator/ParticlePanels/EditPanelBase.Designer.cs
+++ b/Recombobulator/ParticlePanels/EditPanelBase.Designer.cs
@@ -1,0 +1,203 @@
+﻿namespace Recombobulator.ParticlePanels
+{
+    partial class EditPanelBase
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+			this.backPamel = new System.Windows.Forms.Panel();
+			this.particlesPanel = new System.Windows.Forms.Panel();
+			this.fieldsPanel = new System.Windows.Forms.TableLayoutPanel();
+			this.toolBoxPanel = new System.Windows.Forms.Panel();
+			this.addButton = new System.Windows.Forms.Button();
+			this.resetButton = new System.Windows.Forms.Button();
+			this.selectionLabel = new System.Windows.Forms.Label();
+			this.pasteButton = new System.Windows.Forms.Button();
+			this.selectionComboBox = new System.Windows.Forms.ComboBox();
+			this.copyButton = new System.Windows.Forms.Button();
+			this.insertButton = new System.Windows.Forms.Button();
+			this.removeButton = new System.Windows.Forms.Button();
+			this.backPamel.SuspendLayout();
+			this.toolBoxPanel.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// backPamel
+			// 
+			this.backPamel.AutoScroll = true;
+			this.backPamel.Controls.Add(this.particlesPanel);
+			this.backPamel.Controls.Add(this.fieldsPanel);
+			this.backPamel.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.backPamel.Location = new System.Drawing.Point(0, 60);
+			this.backPamel.Name = "backPamel";
+			this.backPamel.Size = new System.Drawing.Size(515, 440);
+			this.backPamel.TabIndex = 15;
+			// 
+			// particlesPanel
+			// 
+			this.particlesPanel.Location = new System.Drawing.Point(254, 10);
+			this.particlesPanel.Margin = new System.Windows.Forms.Padding(0);
+			this.particlesPanel.Name = "particlesPanel";
+			this.particlesPanel.Size = new System.Drawing.Size(240, 940);
+			this.particlesPanel.TabIndex = 2;
+			// 
+			// fieldsPanel
+			// 
+			this.fieldsPanel.ColumnCount = 2;
+			this.fieldsPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 150F));
+			this.fieldsPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
+			this.fieldsPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+			this.fieldsPanel.Location = new System.Drawing.Point(0, 10);
+			this.fieldsPanel.Margin = new System.Windows.Forms.Padding(0);
+			this.fieldsPanel.Name = "fieldsPanel";
+			this.fieldsPanel.Size = new System.Drawing.Size(250, 940);
+			this.fieldsPanel.TabIndex = 1;
+			// 
+			// toolBoxPanel
+			// 
+			this.toolBoxPanel.Controls.Add(this.addButton);
+			this.toolBoxPanel.Controls.Add(this.resetButton);
+			this.toolBoxPanel.Controls.Add(this.selectionLabel);
+			this.toolBoxPanel.Controls.Add(this.pasteButton);
+			this.toolBoxPanel.Controls.Add(this.selectionComboBox);
+			this.toolBoxPanel.Controls.Add(this.copyButton);
+			this.toolBoxPanel.Controls.Add(this.insertButton);
+			this.toolBoxPanel.Controls.Add(this.removeButton);
+			this.toolBoxPanel.Dock = System.Windows.Forms.DockStyle.Top;
+			this.toolBoxPanel.Location = new System.Drawing.Point(0, 0);
+			this.toolBoxPanel.Margin = new System.Windows.Forms.Padding(0);
+			this.toolBoxPanel.Name = "toolBoxPanel";
+			this.toolBoxPanel.Size = new System.Drawing.Size(515, 60);
+			this.toolBoxPanel.TabIndex = 14;
+			// 
+			// addButton
+			// 
+			this.addButton.Enabled = false;
+			this.addButton.Location = new System.Drawing.Point(257, 4);
+			this.addButton.Name = "addButton";
+			this.addButton.Size = new System.Drawing.Size(75, 23);
+			this.addButton.TabIndex = 10;
+			this.addButton.Text = "Add";
+			this.addButton.UseVisualStyleBackColor = true;
+			// 
+			// resetButton
+			// 
+			this.resetButton.Enabled = false;
+			this.resetButton.Location = new System.Drawing.Point(338, 33);
+			this.resetButton.Name = "resetButton";
+			this.resetButton.Size = new System.Drawing.Size(75, 23);
+			this.resetButton.TabIndex = 9;
+			this.resetButton.Text = "Reset";
+			this.resetButton.UseVisualStyleBackColor = true;
+			// 
+			// selectionLabel
+			// 
+			this.selectionLabel.AutoSize = true;
+			this.selectionLabel.Location = new System.Drawing.Point(3, 9);
+			this.selectionLabel.Name = "selectionLabel";
+			this.selectionLabel.Size = new System.Drawing.Size(0, 13);
+			this.selectionLabel.TabIndex = 4;
+			// 
+			// pasteButton
+			// 
+			this.pasteButton.Enabled = false;
+			this.pasteButton.Location = new System.Drawing.Point(419, 33);
+			this.pasteButton.Name = "pasteButton";
+			this.pasteButton.Size = new System.Drawing.Size(75, 23);
+			this.pasteButton.TabIndex = 8;
+			this.pasteButton.Text = "Paste";
+			this.pasteButton.UseVisualStyleBackColor = true;
+			// 
+			// selectionComboBox
+			// 
+			this.selectionComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.selectionComboBox.FormattingEnabled = true;
+			this.selectionComboBox.Location = new System.Drawing.Point(98, 4);
+			this.selectionComboBox.Name = "selectionComboBox";
+			this.selectionComboBox.Size = new System.Drawing.Size(152, 21);
+			this.selectionComboBox.TabIndex = 3;
+			// 
+			// copyButton
+			// 
+			this.copyButton.Enabled = false;
+			this.copyButton.Location = new System.Drawing.Point(419, 4);
+			this.copyButton.Name = "copyButton";
+			this.copyButton.Size = new System.Drawing.Size(75, 23);
+			this.copyButton.TabIndex = 7;
+			this.copyButton.Text = "Copy";
+			this.copyButton.UseVisualStyleBackColor = true;
+			// 
+			// insertButton
+			// 
+			this.insertButton.Enabled = false;
+			this.insertButton.Location = new System.Drawing.Point(338, 4);
+			this.insertButton.Name = "insertButton";
+			this.insertButton.Size = new System.Drawing.Size(75, 23);
+			this.insertButton.TabIndex = 5;
+			this.insertButton.Text = "Insert";
+			this.insertButton.UseVisualStyleBackColor = true;
+			// 
+			// removeButton
+			// 
+			this.removeButton.Enabled = false;
+			this.removeButton.Location = new System.Drawing.Point(257, 33);
+			this.removeButton.Name = "removeButton";
+			this.removeButton.Size = new System.Drawing.Size(75, 23);
+			this.removeButton.TabIndex = 6;
+			this.removeButton.Text = "Remove";
+			this.removeButton.UseVisualStyleBackColor = true;
+			// 
+			// EditPanelBase
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.Controls.Add(this.backPamel);
+			this.Controls.Add(this.toolBoxPanel);
+			this.Margin = new System.Windows.Forms.Padding(0);
+			this.Name = "EditPanelBase";
+			this.Size = new System.Drawing.Size(515, 500);
+			this.backPamel.ResumeLayout(false);
+			this.toolBoxPanel.ResumeLayout(false);
+			this.toolBoxPanel.PerformLayout();
+			this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        protected System.Windows.Forms.Panel backPamel;
+        protected System.Windows.Forms.Panel particlesPanel;
+        protected System.Windows.Forms.TableLayoutPanel fieldsPanel;
+        protected System.Windows.Forms.Panel toolBoxPanel;
+        protected System.Windows.Forms.Label selectionLabel;
+        protected System.Windows.Forms.Button pasteButton;
+        protected System.Windows.Forms.ComboBox selectionComboBox;
+        protected System.Windows.Forms.Button copyButton;
+        protected System.Windows.Forms.Button insertButton;
+        protected System.Windows.Forms.Button removeButton;
+        protected System.Windows.Forms.Button resetButton;
+        protected System.Windows.Forms.Button addButton;
+    }
+}

--- a/Recombobulator/ParticlePanels/EditPanelBase.cs
+++ b/Recombobulator/ParticlePanels/EditPanelBase.cs
@@ -1,0 +1,61 @@
+﻿using Recombobulator.SR1Structures;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Recombobulator.ParticlePanels
+{
+    public partial class EditPanelBase : UserControl
+    {
+        public EditPanelBase()
+        {
+            InitializeComponent();
+		}
+
+		protected TextBox AddField(SR1_Structure structure, string prefix, ref int row)
+		{
+			if (structure.GetType() == typeof(Position))
+			{
+				Position position = (Position)structure;
+				AddField(position.x, structure.Name + ".", ref row);
+				AddField(position.y, structure.Name + ".", ref row);
+				AddField(position.z, structure.Name + ".", ref row);
+				return null;
+			}
+
+			if (structure.GetType() == typeof(SVector))
+			{
+				SVector svector = (SVector)structure;
+				AddField(svector.x, structure.Name + ".", ref row);
+				AddField(svector.y, structure.Name + ".", ref row);
+				AddField(svector.z, structure.Name + ".", ref row);
+				return null;
+			}
+
+			fieldsPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 30f));
+
+			Label nameLabel = new Label();
+			nameLabel.Location = new Point(10, 10);
+			nameLabel.Text = prefix + structure.Name;
+			nameLabel.Size = new Size(120, 30);
+
+			TextBox valueTextBox = new TextBox();
+			valueTextBox.Location = new Point(10, 10);
+			valueTextBox.Name = structure.Name;
+			string valueText = structure.ToString();
+			if (structure is SR1_PrimativeBase &&
+				((SR1_PrimativeBase)structure).IsShowAsHex())
+			{
+				valueText = valueText.Substring(2);
+			}
+			valueTextBox.Text = valueText;
+			valueTextBox.Size = new Size(80, 30);
+
+			fieldsPanel.Controls.Add(nameLabel, 0, row);
+			fieldsPanel.Controls.Add(valueTextBox, 1, row);
+
+			row++;
+
+			return valueTextBox;
+		}
+	}
+}

--- a/Recombobulator/ParticlePanels/EditPanelBase.resx
+++ b/Recombobulator/ParticlePanels/EditPanelBase.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Recombobulator/ParticlePanels/EditParticlesPanel.Designer.cs
+++ b/Recombobulator/ParticlePanels/EditParticlesPanel.Designer.cs
@@ -1,0 +1,127 @@
+﻿namespace Recombobulator.ParticlePanels
+{
+    partial class EditParticlesPanel
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+			this.endColorBox = new System.Windows.Forms.PictureBox();
+			this.startColorBox = new System.Windows.Forms.PictureBox();
+			this.backPamel.SuspendLayout();
+			this.particlesPanel.SuspendLayout();
+			this.fieldsPanel.SuspendLayout();
+			this.toolBoxPanel.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.endColorBox)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.startColorBox)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// particlesPanel
+			// 
+			this.particlesPanel.Controls.Add(this.endColorBox);
+			this.particlesPanel.Controls.Add(this.startColorBox);
+			this.particlesPanel.Size = new System.Drawing.Size(240, 1100);
+			// 
+			// fieldsPanel
+			// 
+			this.fieldsPanel.Size = new System.Drawing.Size(250, 1100);
+			// 
+			// selectionLabel
+			// 
+			this.selectionLabel.Size = new System.Drawing.Size(79, 13);
+			this.selectionLabel.Text = "Current Particle";
+			// 
+			// pasteButton
+			// 
+			this.pasteButton.Click += new System.EventHandler(this.pasteButton_Click);
+			// 
+			// selectionComboBox
+			// 
+			this.selectionComboBox.SelectedIndexChanged += new System.EventHandler(this.selectionComboBox_SelectedIndexChanged);
+			// 
+			// copyButton
+			// 
+			this.copyButton.Click += new System.EventHandler(this.copyButton_Click);
+			// 
+			// insertButton
+			// 
+			this.insertButton.Click += new System.EventHandler(this.insertButton_Click);
+			// 
+			// removeButton
+			// 
+			this.removeButton.Click += new System.EventHandler(this.removeButton_Click);
+			// 
+			// resetButton
+			// 
+			this.resetButton.Click += new System.EventHandler(this.resetButton_Click);
+			// 
+			// addButton
+			// 
+			this.addButton.Click += new System.EventHandler(this.addButton_Click);
+			// 
+			// endColorBox
+			// 
+			this.endColorBox.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+			this.endColorBox.Location = new System.Drawing.Point(95, 575);
+			this.endColorBox.Margin = new System.Windows.Forms.Padding(0);
+			this.endColorBox.Name = "endColorBox";
+			this.endColorBox.Size = new System.Drawing.Size(50, 50);
+			this.endColorBox.TabIndex = 6;
+			this.endColorBox.TabStop = false;
+			this.endColorBox.Visible = false;
+			// 
+			// startColorBox
+			// 
+			this.startColorBox.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+			this.startColorBox.Location = new System.Drawing.Point(95, 455);
+			this.startColorBox.Margin = new System.Windows.Forms.Padding(0);
+			this.startColorBox.Name = "startColorBox";
+			this.startColorBox.Size = new System.Drawing.Size(50, 50);
+			this.startColorBox.TabIndex = 5;
+			this.startColorBox.TabStop = false;
+			this.startColorBox.Visible = false;
+			// 
+			// EditParticlesPanel
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.Name = "EditParticlesPanel";
+			this.backPamel.ResumeLayout(false);
+			this.particlesPanel.ResumeLayout(false);
+			this.fieldsPanel.ResumeLayout(false);
+			this.toolBoxPanel.ResumeLayout(false);
+			this.toolBoxPanel.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.endColorBox)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.startColorBox)).EndInit();
+			this.ResumeLayout(false);
+
+        }
+
+		#endregion
+
+		private System.Windows.Forms.PictureBox endColorBox;
+		private System.Windows.Forms.PictureBox startColorBox;
+	}
+}

--- a/Recombobulator/ParticlePanels/EditParticlesPanel.cs
+++ b/Recombobulator/ParticlePanels/EditParticlesPanel.cs
@@ -1,0 +1,288 @@
+﻿using Recombobulator.SR1Structures;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+using System;
+
+namespace Recombobulator.ParticlePanels
+{
+    public partial class EditParticlesPanel : EditPanelBase
+    {
+        SR1_StructureSeries<GenericParticleParams> _particlesList = null;
+        SR1_StructureSeries<GenericParticleParams> _particlesListBackup = null;
+        GenericParticleParams _copiedParticleParams = new GenericParticleParams();
+
+        public EditParticlesPanel()
+        {
+            InitializeComponent();
+        }
+
+        public void Open(object particlesList, object particlesListBackup = null)
+        {
+            _particlesList = (SR1_StructureSeries<GenericParticleParams>)particlesList;
+            _particlesListBackup = (SR1_StructureSeries<GenericParticleParams>)particlesListBackup;
+
+            selectionComboBox.SelectedIndex = -1;
+            selectionComboBox.Items.Clear();
+            for (int i = 0; i < _particlesList.Count; i++)
+            {
+                selectionComboBox.Items.Add("particle-" + i.ToString());
+            }
+
+            selectionComboBox.SelectedIndex = 0;
+        }
+
+        private void startColor_TextChanged(object sender, EventArgs e)
+        {
+            byte startRed = 0;
+            byte startGreen = 0;
+            byte startBlue = 0;
+
+            foreach (Control control in fieldsPanel.Controls)
+            {
+                if (control.Name == "startColor_red")
+                {
+                    byte.TryParse(control.Text, out startRed);
+                }
+
+                if (control.Name == "startColor_green")
+                {
+                    byte.TryParse(control.Text, out startGreen);
+                }
+
+                if (control.Name == "startColor_blue")
+                {
+                    byte.TryParse(control.Text, out startBlue);
+                }
+            }
+
+            startColorBox.BackColor = Color.FromArgb(startRed, startGreen, startBlue);
+        }
+
+        private void endColor_TextChanged(object sender, EventArgs e)
+        {
+            byte endRed = 0;
+            byte endGreen = 0;
+            byte endBlue = 0;
+
+            foreach (Control control in fieldsPanel.Controls)
+            {
+                if (control.Name == "endColor_red")
+                {
+                    byte.TryParse(control.Text, out endRed);
+                }
+
+                if (control.Name == "endColor_green")
+                {
+                    byte.TryParse(control.Text, out endGreen);
+                }
+
+                if (control.Name == "endColor_blue")
+                {
+                    byte.TryParse(control.Text, out endBlue);
+                }
+            }
+
+            endColorBox.BackColor = Color.FromArgb(endRed, endGreen, endBlue);
+        }
+
+		private void selectionComboBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			int newIndex = selectionComboBox.SelectedIndex;
+
+			insertButton.Enabled = false;
+			removeButton.Enabled = false;
+			resetButton.Enabled = false;
+			addButton.Enabled = false;
+			copyButton.Enabled = false;
+			pasteButton.Enabled = false;
+
+			startColorBox.Visible = false;
+			endColorBox.Visible = false;
+
+			fieldsPanel.Controls.Clear();
+			fieldsPanel.RowStyles.Clear();
+
+			if (newIndex < 0)
+			{
+				return;
+			}
+
+			addButton.Enabled = true;
+			copyButton.Enabled = true;
+			pasteButton.Enabled = true;
+
+			if (_particlesListBackup != null)
+			{
+				if (newIndex < _particlesListBackup.Count)
+				{
+					insertButton.Enabled = false;
+					removeButton.Enabled = false;
+					resetButton.Enabled = true;
+				}
+				else
+				{
+					insertButton.Enabled = true;
+					removeButton.Enabled = true;
+					resetButton.Enabled = false;
+				}
+			}
+			else
+			{
+				insertButton.Enabled = true;
+				removeButton.Enabled = true;
+				resetButton.Enabled = false;
+			}
+
+			startColorBox.Visible = true;
+			endColorBox.Visible = true;
+
+			List<SR1_Structure> membersRead = _particlesList[newIndex].MembersRead;
+			fieldsPanel.RowCount = membersRead.Count;
+
+			int row = 0;
+			int startRed = 0;
+			int startGreen = 0;
+			int startBlue = 0;
+			int endRed = 0;
+			int endGreen = 0;
+			int endBlue = 0;
+			foreach (SR1_Structure structure in membersRead)
+			{
+				TextBox valueTextBox = AddField(structure, "", ref row);
+
+				if (structure.Name == "startColor_red")
+				{
+					startRed = ((SR1_Primative<byte>)structure).Value;
+					valueTextBox.TextChanged += startColor_TextChanged;
+				}
+
+				if (structure.Name == "startColor_green")
+				{
+					startGreen = ((SR1_Primative<byte>)structure).Value;
+					valueTextBox.TextChanged += startColor_TextChanged;
+				}
+
+				if (structure.Name == "startColor_blue")
+				{
+					startBlue = ((SR1_Primative<byte>)structure).Value;
+					valueTextBox.TextChanged += startColor_TextChanged;
+				}
+
+				if (structure.Name == "endColor_red")
+				{
+					endRed = ((SR1_Primative<byte>)structure).Value;
+					valueTextBox.TextChanged += endColor_TextChanged;
+				}
+
+				if (structure.Name == "endColor_green")
+				{
+					endGreen = ((SR1_Primative<byte>)structure).Value;
+				}
+
+				if (structure.Name == "endColor_blue")
+				{
+					endBlue = ((SR1_Primative<byte>)structure).Value;
+					valueTextBox.TextChanged += endColor_TextChanged;
+				}
+			}
+
+			startColorBox.BackColor = Color.FromArgb(startRed, startGreen, startBlue);
+			endColorBox.BackColor = Color.FromArgb(endRed, endGreen, endBlue);
+
+			fieldsPanel.Visible = true;
+			fieldsPanel.Enabled = true;
+		}
+
+		private void addButton_Click(object sender, EventArgs e)
+        {
+            _particlesList.Add(new GenericParticleParams());
+            selectionComboBox.SelectedIndex = _particlesList.Count - 1;
+        }
+
+        private void insertButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (currentIndex < 0)
+            {
+                return;
+            }
+
+            currentIndex = Math.Min(currentIndex, _particlesList.Count);
+
+            _particlesList.InsertAt(currentIndex, new GenericParticleParams());
+            selectionComboBox.SelectedIndex = -1;
+            selectionComboBox.SelectedIndex = currentIndex;
+        }
+
+        private void removeButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (currentIndex < 0 || currentIndex >= selectionComboBox.Items.Count)
+            {
+                return;
+            }
+
+            _particlesList.RemoveAt(currentIndex);
+            selectionComboBox.SelectedIndex = -1;
+
+            if (selectionComboBox.Items.Count > 0)
+            {
+                currentIndex = Math.Min(currentIndex, _particlesList.Count - 1);
+                selectionComboBox.SelectedIndex = currentIndex;
+            }
+        }
+
+        private void copyButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (currentIndex < 0 ||
+                currentIndex >= _particlesList.Count)
+            {
+                return;
+            }
+
+            GenericParticleParams.Copy(_copiedParticleParams, (GenericParticleParams)_particlesList[currentIndex]);
+        }
+
+        private void pasteButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (currentIndex < 0 ||
+                currentIndex >= _particlesList.Count)
+            {
+                return;
+            }
+
+            GenericParticleParams.Copy((GenericParticleParams)_particlesList[currentIndex], _copiedParticleParams);
+
+            selectionComboBox.SelectedIndex = -1;
+            selectionComboBox.SelectedIndex = currentIndex;
+        }
+
+        private void resetButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (_particlesListBackup == null ||
+                currentIndex < 0 ||
+                currentIndex >= _particlesList.Count ||
+                currentIndex >= _particlesListBackup.Count)
+            {
+                return;
+            }
+
+            GenericParticleParams.Copy(
+                (GenericParticleParams)_particlesList[currentIndex],
+                (GenericParticleParams)_particlesListBackup[currentIndex]
+            );
+
+            selectionComboBox.SelectedIndex = -1;
+            selectionComboBox.SelectedIndex = currentIndex;
+        }
+    }
+}

--- a/Recombobulator/ParticlePanels/EditParticlesPanel.resx
+++ b/Recombobulator/ParticlePanels/EditParticlesPanel.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Recombobulator/ParticlePanels/EditRibbonsPanel.Designer.cs
+++ b/Recombobulator/ParticlePanels/EditRibbonsPanel.Designer.cs
@@ -1,0 +1,120 @@
+﻿namespace Recombobulator.ParticlePanels
+{
+    partial class EditRibbonsPanel
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+			this.endColorBox = new System.Windows.Forms.PictureBox();
+			this.startColorBox = new System.Windows.Forms.PictureBox();
+			this.backPamel.SuspendLayout();
+			this.particlesPanel.SuspendLayout();
+			this.toolBoxPanel.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.endColorBox)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.startColorBox)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// particlesPanel
+			// 
+			this.particlesPanel.Controls.Add(this.endColorBox);
+			this.particlesPanel.Controls.Add(this.startColorBox);
+			// 
+			// selectionLabel
+			// 
+			this.selectionLabel.Size = new System.Drawing.Size(78, 13);
+			this.selectionLabel.Text = "Current Ribbon";
+			// 
+			// pasteButton
+			// 
+			this.pasteButton.Click += new System.EventHandler(this.pasteButton_Click);
+			// 
+			// selectionComboBox
+			// 
+			this.selectionComboBox.SelectedIndexChanged += new System.EventHandler(this.selectionComboBox_SelectedIndexChanged);
+			// 
+			// copyButton
+			// 
+			this.copyButton.Click += new System.EventHandler(this.copyButton_Click);
+			// 
+			// insertButton
+			// 
+			this.insertButton.Click += new System.EventHandler(this.insertButton_Click);
+			// 
+			// removeButton
+			// 
+			this.removeButton.Click += new System.EventHandler(this.removeButton_Click);
+			// 
+			// resetButton
+			// 
+			this.resetButton.Click += new System.EventHandler(this.resetButton_Click);
+			// 
+			// addButton
+			// 
+			this.addButton.Click += new System.EventHandler(this.addButton_Click);
+			// 
+			// endColorBox
+			// 
+			this.endColorBox.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+			this.endColorBox.Location = new System.Drawing.Point(165, 275);
+			this.endColorBox.Margin = new System.Windows.Forms.Padding(0);
+			this.endColorBox.Name = "endColorBox";
+			this.endColorBox.Size = new System.Drawing.Size(50, 50);
+			this.endColorBox.TabIndex = 6;
+			this.endColorBox.TabStop = false;
+			this.endColorBox.Visible = false;
+			// 
+			// startColorBox
+			// 
+			this.startColorBox.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+			this.startColorBox.Location = new System.Drawing.Point(95, 275);
+			this.startColorBox.Margin = new System.Windows.Forms.Padding(0);
+			this.startColorBox.Name = "startColorBox";
+			this.startColorBox.Size = new System.Drawing.Size(50, 50);
+			this.startColorBox.TabIndex = 5;
+			this.startColorBox.TabStop = false;
+			this.startColorBox.Visible = false;
+			// 
+			// EditRibbonsPanel
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.Name = "EditRibbonsPanel";
+			this.backPamel.ResumeLayout(false);
+			this.particlesPanel.ResumeLayout(false);
+			this.toolBoxPanel.ResumeLayout(false);
+			this.toolBoxPanel.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.endColorBox)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.startColorBox)).EndInit();
+			this.ResumeLayout(false);
+
+        }
+
+		#endregion
+
+		private System.Windows.Forms.PictureBox endColorBox;
+		private System.Windows.Forms.PictureBox startColorBox;
+	}
+}

--- a/Recombobulator/ParticlePanels/EditRibbonsPanel.cs
+++ b/Recombobulator/ParticlePanels/EditRibbonsPanel.cs
@@ -1,0 +1,243 @@
+﻿using Recombobulator.SR1Structures;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+using System;
+using System.Globalization;
+
+namespace Recombobulator.ParticlePanels
+{
+    public partial class EditRibbonsPanel : EditPanelBase
+    {
+        SR1_StructureSeries<GenericRibbonParams> _ribbonsList = null;
+        SR1_StructureSeries<GenericRibbonParams> _ribbonsListBackup = null;
+        GenericRibbonParams _copiedRibbonParams = new GenericRibbonParams();
+
+        public EditRibbonsPanel()
+        {
+            InitializeComponent();
+        }
+
+        public void Open(object ribbonsList, object ribbonsListBackup = null)
+        {
+            _ribbonsList = (SR1_StructureSeries<GenericRibbonParams>)ribbonsList;
+            _ribbonsListBackup = (SR1_StructureSeries<GenericRibbonParams>)ribbonsListBackup;
+
+            selectionComboBox.SelectedIndex = -1;
+            selectionComboBox.Items.Clear();
+            for (int i = 0; i < _ribbonsList.Count; i++)
+            {
+                selectionComboBox.Items.Add("ribbon-" + i.ToString());
+            }
+
+            selectionComboBox.SelectedIndex = 0;
+        }
+
+        private void startColor_TextChanged(object sender, EventArgs e)
+        {
+            int startColor = 0;
+
+            foreach (Control control in fieldsPanel.Controls)
+            {
+                if (control.Name == "startColor")
+				{
+					int.TryParse(control.Text, NumberStyles.HexNumber, NumberFormatInfo.CurrentInfo, out startColor);
+					startColor |= unchecked((int)0xFF000000);
+				}
+            }
+
+            startColorBox.BackColor = Color.FromArgb(startColor);
+        }
+
+        private void endColor_TextChanged(object sender, EventArgs e)
+		{
+			int endColor = 0;
+
+			foreach (Control control in fieldsPanel.Controls)
+			{
+				if (control.Name == "endColor")
+				{
+                    int.TryParse(control.Text, NumberStyles.HexNumber, NumberFormatInfo.CurrentInfo, out endColor);
+                    endColor |= unchecked((int)0xFF000000);
+				}
+			}
+
+			endColorBox.BackColor = Color.FromArgb(endColor);
+		}
+
+		private void selectionComboBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			int newIndex = selectionComboBox.SelectedIndex;
+
+			insertButton.Enabled = false;
+			removeButton.Enabled = false;
+			resetButton.Enabled = false;
+			addButton.Enabled = false;
+			copyButton.Enabled = false;
+			pasteButton.Enabled = false;
+
+			startColorBox.Visible = false;
+			endColorBox.Visible = false;
+
+			fieldsPanel.Controls.Clear();
+			fieldsPanel.RowStyles.Clear();
+
+			if (newIndex < 0)
+			{
+				return;
+			}
+
+			addButton.Enabled = true;
+			copyButton.Enabled = true;
+			pasteButton.Enabled = true;
+
+			if (_ribbonsListBackup != null)
+			{
+				if (newIndex < _ribbonsListBackup.Count)
+				{
+					insertButton.Enabled = false;
+					removeButton.Enabled = false;
+					resetButton.Enabled = true;
+				}
+				else
+				{
+					insertButton.Enabled = true;
+					removeButton.Enabled = true;
+					resetButton.Enabled = false;
+				}
+			}
+			else
+			{
+				insertButton.Enabled = true;
+				removeButton.Enabled = true;
+				resetButton.Enabled = false;
+			}
+
+			startColorBox.Visible = true;
+			endColorBox.Visible = true;
+
+			List<SR1_Structure> membersRead = _ribbonsList[newIndex].MembersRead;
+			fieldsPanel.RowCount = membersRead.Count;
+
+			int row = 0;
+			int startColor = 0;
+			int endColor = 0;
+			foreach (SR1_Structure structure in membersRead)
+			{
+				TextBox valueTextBox = AddField(structure, "", ref row);
+
+				if (structure.Name == "startColor")
+				{
+					startColor = ((SR1_Primative<int>)structure).Value;
+					valueTextBox.TextChanged += startColor_TextChanged;
+				}
+
+				if (structure.Name == "endColor")
+				{
+					endColor = ((SR1_Primative<int>)structure).Value;
+					valueTextBox.TextChanged += endColor_TextChanged;
+				}
+			}
+
+			startColor |= unchecked((int)0xFF000000);
+			endColor |= unchecked((int)0xFF000000);
+
+			startColorBox.BackColor = Color.FromArgb(startColor);
+			endColorBox.BackColor = Color.FromArgb(endColor);
+
+			fieldsPanel.Visible = true;
+			fieldsPanel.Enabled = true;
+		}
+
+		private void addButton_Click(object sender, EventArgs e)
+        {
+            _ribbonsList.Add(new GenericRibbonParams());
+            selectionComboBox.SelectedIndex = _ribbonsList.Count - 1;
+        }
+
+        private void insertButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (currentIndex < 0)
+            {
+                return;
+            }
+
+            currentIndex = Math.Min(currentIndex, _ribbonsList.Count);
+
+            _ribbonsList.InsertAt(currentIndex, new GenericRibbonParams());
+            selectionComboBox.SelectedIndex = -1;
+            selectionComboBox.SelectedIndex = currentIndex;
+        }
+
+        private void removeButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (currentIndex < 0 || currentIndex >= selectionComboBox.Items.Count)
+            {
+                return;
+            }
+
+            _ribbonsList.RemoveAt(currentIndex);
+            selectionComboBox.SelectedIndex = -1;
+
+            if (selectionComboBox.Items.Count > 0)
+            {
+                currentIndex = Math.Min(currentIndex, _ribbonsList.Count - 1);
+                selectionComboBox.SelectedIndex = currentIndex;
+            }
+        }
+
+        private void copyButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (currentIndex < 0 ||
+                currentIndex >= _ribbonsList.Count)
+            {
+                return;
+            }
+
+            GenericRibbonParams.Copy(_copiedRibbonParams, (GenericRibbonParams)_ribbonsList[currentIndex]);
+        }
+
+        private void pasteButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (currentIndex < 0 ||
+                currentIndex >= _ribbonsList.Count)
+            {
+                return;
+            }
+
+            GenericRibbonParams.Copy((GenericRibbonParams)_ribbonsList[currentIndex], _copiedRibbonParams);
+
+            selectionComboBox.SelectedIndex = -1;
+            selectionComboBox.SelectedIndex = currentIndex;
+        }
+
+        private void resetButton_Click(object sender, EventArgs e)
+        {
+            int currentIndex = selectionComboBox.SelectedIndex;
+
+            if (_ribbonsListBackup == null ||
+                currentIndex < 0 ||
+                currentIndex >= _ribbonsList.Count ||
+                currentIndex >= _ribbonsListBackup.Count)
+            {
+                return;
+            }
+
+            GenericRibbonParams.Copy(
+                (GenericRibbonParams)_ribbonsList[currentIndex],
+                (GenericRibbonParams)_ribbonsListBackup[currentIndex]
+            );
+
+            selectionComboBox.SelectedIndex = -1;
+            selectionComboBox.SelectedIndex = currentIndex;
+        }
+    }
+}

--- a/Recombobulator/ParticlePanels/EditRibbonsPanel.resx
+++ b/Recombobulator/ParticlePanels/EditRibbonsPanel.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Recombobulator/ParticlePanels/MainParticlesPanel.Designer.cs
+++ b/Recombobulator/ParticlePanels/MainParticlesPanel.Designer.cs
@@ -1,0 +1,182 @@
+﻿namespace Recombobulator.ParticlePanels
+{
+	partial class MainParticlesPanel
+	{
+		/// <summary> 
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary> 
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Component Designer generated code
+
+		/// <summary> 
+		/// Required method for Designer support - do not modify 
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent()
+		{
+			this.splitContainer = new System.Windows.Forms.SplitContainer();
+			this.categoriesTreeView = new System.Windows.Forms.TreeView();
+			this.backPamel = new System.Windows.Forms.Panel();
+			this.editFlashesPanel = new Recombobulator.ParticlePanels.EditFlashesPanel();
+			this.editBlastRingsPanel = new Recombobulator.ParticlePanels.EditBlastRingsPanel();
+			this.editLightningsPanel = new Recombobulator.ParticlePanels.EditLightningsPanel();
+			this.editGlowsPanel = new Recombobulator.ParticlePanels.EditGlowsPanel();
+			this.editRibbonsPanel = new Recombobulator.ParticlePanels.EditRibbonsPanel();
+			this.editParticlesPanel = new Recombobulator.ParticlePanels.EditParticlesPanel();
+			((System.ComponentModel.ISupportInitialize)(this.splitContainer)).BeginInit();
+			this.splitContainer.Panel1.SuspendLayout();
+			this.splitContainer.Panel2.SuspendLayout();
+			this.splitContainer.SuspendLayout();
+			this.backPamel.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// splitContainer
+			// 
+			this.splitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.splitContainer.Location = new System.Drawing.Point(0, 0);
+			this.splitContainer.Name = "splitContainer";
+			// 
+			// splitContainer.Panel1
+			// 
+			this.splitContainer.Panel1.Controls.Add(this.categoriesTreeView);
+			// 
+			// splitContainer.Panel2
+			// 
+			this.splitContainer.Panel2.Controls.Add(this.backPamel);
+			this.splitContainer.Size = new System.Drawing.Size(700, 489);
+			this.splitContainer.SplitterDistance = 129;
+			this.splitContainer.TabIndex = 1;
+			// 
+			// categoriesTreeView
+			// 
+			this.categoriesTreeView.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.categoriesTreeView.Location = new System.Drawing.Point(0, 0);
+			this.categoriesTreeView.Name = "categoriesTreeView";
+			this.categoriesTreeView.Size = new System.Drawing.Size(129, 489);
+			this.categoriesTreeView.TabIndex = 0;
+			this.categoriesTreeView.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.categoriesTreeView_AfterSelect);
+			// 
+			// backPamel
+			// 
+			this.backPamel.AutoScroll = true;
+			this.backPamel.Controls.Add(this.editFlashesPanel);
+			this.backPamel.Controls.Add(this.editBlastRingsPanel);
+			this.backPamel.Controls.Add(this.editLightningsPanel);
+			this.backPamel.Controls.Add(this.editGlowsPanel);
+			this.backPamel.Controls.Add(this.editRibbonsPanel);
+			this.backPamel.Controls.Add(this.editParticlesPanel);
+			this.backPamel.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.backPamel.Location = new System.Drawing.Point(0, 0);
+			this.backPamel.Name = "backPamel";
+			this.backPamel.Size = new System.Drawing.Size(567, 489);
+			this.backPamel.TabIndex = 13;
+			// 
+			// editFlashesPanel
+			// 
+			this.editFlashesPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.editFlashesPanel.Enabled = false;
+			this.editFlashesPanel.Location = new System.Drawing.Point(0, 0);
+			this.editFlashesPanel.Margin = new System.Windows.Forms.Padding(0);
+			this.editFlashesPanel.Name = "editFlashesPanel";
+			this.editFlashesPanel.Size = new System.Drawing.Size(567, 489);
+			this.editFlashesPanel.TabIndex = 5;
+			this.editFlashesPanel.Visible = false;
+			// 
+			// editBlastRingsPanel
+			// 
+			this.editBlastRingsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.editBlastRingsPanel.Enabled = false;
+			this.editBlastRingsPanel.Location = new System.Drawing.Point(0, 0);
+			this.editBlastRingsPanel.Margin = new System.Windows.Forms.Padding(0);
+			this.editBlastRingsPanel.Name = "editBlastRingsPanel";
+			this.editBlastRingsPanel.Size = new System.Drawing.Size(567, 489);
+			this.editBlastRingsPanel.TabIndex = 4;
+			this.editBlastRingsPanel.Visible = false;
+			// 
+			// editLightningsPanel
+			// 
+			this.editLightningsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.editLightningsPanel.Enabled = false;
+			this.editLightningsPanel.Location = new System.Drawing.Point(0, 0);
+			this.editLightningsPanel.Margin = new System.Windows.Forms.Padding(0);
+			this.editLightningsPanel.Name = "editLightningsPanel";
+			this.editLightningsPanel.Size = new System.Drawing.Size(567, 489);
+			this.editLightningsPanel.TabIndex = 3;
+			this.editLightningsPanel.Visible = false;
+			// 
+			// editGlowsPanel
+			// 
+			this.editGlowsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.editGlowsPanel.Enabled = false;
+			this.editGlowsPanel.Location = new System.Drawing.Point(0, 0);
+			this.editGlowsPanel.Margin = new System.Windows.Forms.Padding(0);
+			this.editGlowsPanel.Name = "editGlowsPanel";
+			this.editGlowsPanel.Size = new System.Drawing.Size(567, 489);
+			this.editGlowsPanel.TabIndex = 2;
+			this.editGlowsPanel.Visible = false;
+			// 
+			// editRibbonsPanel
+			// 
+			this.editRibbonsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.editRibbonsPanel.Enabled = false;
+			this.editRibbonsPanel.Location = new System.Drawing.Point(0, 0);
+			this.editRibbonsPanel.Margin = new System.Windows.Forms.Padding(0);
+			this.editRibbonsPanel.Name = "editRibbonsPanel";
+			this.editRibbonsPanel.Size = new System.Drawing.Size(567, 489);
+			this.editRibbonsPanel.TabIndex = 1;
+			this.editRibbonsPanel.Visible = false;
+			// 
+			// editParticlesPanel
+			// 
+			this.editParticlesPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.editParticlesPanel.Enabled = false;
+			this.editParticlesPanel.Location = new System.Drawing.Point(0, 0);
+			this.editParticlesPanel.Margin = new System.Windows.Forms.Padding(0);
+			this.editParticlesPanel.Name = "editParticlesPanel";
+			this.editParticlesPanel.Size = new System.Drawing.Size(567, 489);
+			this.editParticlesPanel.TabIndex = 0;
+			this.editParticlesPanel.Visible = false;
+			// 
+			// MainParticlesPanel
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.Controls.Add(this.splitContainer);
+			this.Name = "MainParticlesPanel";
+			this.Size = new System.Drawing.Size(700, 489);
+			this.splitContainer.Panel1.ResumeLayout(false);
+			this.splitContainer.Panel2.ResumeLayout(false);
+			((System.ComponentModel.ISupportInitialize)(this.splitContainer)).EndInit();
+			this.splitContainer.ResumeLayout(false);
+			this.backPamel.ResumeLayout(false);
+			this.ResumeLayout(false);
+
+		}
+
+		#endregion
+
+		private System.Windows.Forms.SplitContainer splitContainer;
+		private System.Windows.Forms.TreeView categoriesTreeView;
+		private System.Windows.Forms.Panel backPamel;
+		private EditParticlesPanel editParticlesPanel;
+		private EditRibbonsPanel editRibbonsPanel;
+		private EditGlowsPanel editGlowsPanel;
+		private EditLightningsPanel editLightningsPanel;
+		private EditBlastRingsPanel editBlastRingsPanel;
+		private EditFlashesPanel editFlashesPanel;
+	}
+}

--- a/Recombobulator/ParticlePanels/MainParticlesPanel.cs
+++ b/Recombobulator/ParticlePanels/MainParticlesPanel.cs
@@ -1,0 +1,150 @@
+﻿using Recombobulator.SR1Structures;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using TreeList;
+using static Recombobulator.SR1_File;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement.Window;
+
+namespace Recombobulator.ParticlePanels
+{
+	public partial class MainParticlesPanel : UserControl
+	{
+		SR1_File _file = new SR1_File();
+		SR1_File _fileBackup = new SR1_File();
+		bool _isFileLoaded = false;
+		bool _hasBackup = false;
+
+		public MainParticlesPanel()
+		{
+			InitializeComponent();
+
+			categoriesTreeView.Nodes.Add(CreateNode("Particles", editParticlesPanel));
+			categoriesTreeView.Nodes.Add(CreateNode("Ribbons", editRibbonsPanel));
+			categoriesTreeView.Nodes.Add(CreateNode("Glows", editGlowsPanel));
+			categoriesTreeView.Nodes.Add(CreateNode("Lightnings", editLightningsPanel));
+			categoriesTreeView.Nodes.Add(CreateNode("BlastRings", editBlastRingsPanel));
+			categoriesTreeView.Nodes.Add(CreateNode("Flashes", editFlashesPanel));
+
+			categoriesTreeView.SelectedNode = categoriesTreeView.Nodes[0];
+		}
+
+		protected TreeNode CreateNode(string name, UserControl control)
+		{
+			TreeNode node = new TreeNode(name);
+			node.Tag = control;
+			return node;
+		}
+
+		public void Open(string filePath, string backupFilePath = null)
+		{
+			try
+			{
+				_file.Import(filePath, SR1_File.ImportFlags.None, SR1_File.Version.Retail_PC);
+				_isFileLoaded = true;
+
+				if (backupFilePath != null)
+				{
+					_fileBackup.Import(backupFilePath, SR1_File.ImportFlags.None, SR1_File.Version.Retail_PC);
+					_hasBackup = true;
+				}
+				else
+				{
+					_fileBackup.Reset();
+					_hasBackup = false;
+				}
+			}
+			catch (Exception ex)
+			{
+				_file.Reset();
+				_fileBackup.Reset();
+				_isFileLoaded = false;
+				_hasBackup = false;
+				return;
+			}
+
+			var srObject = (SR1Structures.Object)_file._Structures[0];
+			var genericFXObject = (GenericFXObject)_file._Structures[srObject.data.Offset];
+			var particlesList = (SR1_StructureSeries<GenericParticleParams>)_file._Structures[genericFXObject.ParticleList.Offset];
+			var ribbonList = (SR1_StructureSeries<GenericRibbonParams>)_file._Structures[genericFXObject.RibbonList.Offset];
+			var glowList = (SR1_StructureSeries<GenericGlowParams>)_file._Structures[genericFXObject.GlowList.Offset];
+			var lightningList = (SR1_StructureSeries<GenericLightningParams>)_file._Structures[genericFXObject.LightningList.Offset];
+			var blastList = (SR1_StructureSeries<GenericBlastRingParams>)_file._Structures[genericFXObject.BlastList.Offset];
+			var flashList = (SR1_StructureSeries<GenericFlashParams>)_file._Structures[genericFXObject.FlashList.Offset];
+
+			if (_hasBackup)
+			{
+				var srBackupObject = (SR1Structures.Object)_fileBackup._Structures[0];
+				var backupGenericFXObject = (GenericFXObject)_fileBackup._Structures[srBackupObject.data.Offset];
+				var backupParticlesList = (SR1_StructureSeries<GenericParticleParams>)_fileBackup._Structures[backupGenericFXObject.ParticleList.Offset];
+				var backupRibbonList = (SR1_StructureSeries<GenericRibbonParams>)_fileBackup._Structures[genericFXObject.RibbonList.Offset];
+				var backupGlowList = (SR1_StructureSeries<GenericGlowParams>)_fileBackup._Structures[genericFXObject.GlowList.Offset];
+				var backupLightningList = (SR1_StructureSeries<GenericLightningParams>)_fileBackup._Structures[genericFXObject.LightningList.Offset];
+				var backupBlastList = (SR1_StructureSeries<GenericBlastRingParams>)_fileBackup._Structures[genericFXObject.BlastList.Offset];
+				var backupFlashList = (SR1_StructureSeries<GenericFlashParams>)_fileBackup._Structures[genericFXObject.FlashList.Offset];
+
+				editParticlesPanel.Open(particlesList, backupParticlesList);
+				editRibbonsPanel.Open(ribbonList, backupRibbonList);
+				editGlowsPanel.Open(glowList, backupGlowList);
+				editLightningsPanel.Open(lightningList, backupLightningList);
+				editBlastRingsPanel.Open(blastList, backupBlastList);
+				editFlashesPanel.Open(flashList, backupFlashList);
+			}
+			else
+			{
+				editParticlesPanel.Open(particlesList, null);
+				editRibbonsPanel.Open(particlesList, null);
+				editGlowsPanel.Open(particlesList, null);
+				editLightningsPanel.Open(particlesList, null);
+				editBlastRingsPanel.Open(particlesList, null);
+				editFlashesPanel.Open(particlesList, null);
+			}
+		}
+
+		public void Save(string filePath)
+		{
+			if (!_isFileLoaded)
+			{
+				return;
+			}
+
+			try
+			{
+				_file.Export(filePath, SR1_File.Version.Retail_PC, MigrateFlags.None, new Overrides());
+			}
+			catch (Exception ex)
+			{
+			}
+		}
+
+		private void categoriesTreeView_AfterSelect(object sender, TreeViewEventArgs e)
+		{
+			foreach (TreeNode node in categoriesTreeView.Nodes)
+			{
+				UserControl control = node.Tag as UserControl;
+				if (control == null)
+				{
+					continue;
+				}
+
+				if (node == categoriesTreeView.SelectedNode)
+				{
+					control.Visible = true;
+					control.Enabled = true;
+					continue;
+				}
+
+
+				control.Visible = false;
+				control.Enabled = false;
+			}
+		}
+	}
+}

--- a/Recombobulator/ParticlePanels/MainParticlesPanel.resx
+++ b/Recombobulator/ParticlePanels/MainParticlesPanel.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Recombobulator/Recombobulator.csproj
+++ b/Recombobulator/Recombobulator.csproj
@@ -84,6 +84,54 @@
     <Compile Include="EditPortalForm.Designer.cs">
       <DependentUpon>EditPortalForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="ParticlePanels\EditPanelBase.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="ParticlePanels\EditPanelBase.Designer.cs">
+      <DependentUpon>EditPanelBase.cs</DependentUpon>
+    </Compile>
+    <Compile Include="ParticlePanels\EditBlastRingsPanel.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="ParticlePanels\EditBlastRingsPanel.Designer.cs">
+      <DependentUpon>EditBlastRingsPanel.cs</DependentUpon>
+    </Compile>
+    <Compile Include="ParticlePanels\EditFlashesPanel.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="ParticlePanels\EditFlashesPanel.Designer.cs">
+      <DependentUpon>EditFlashesPanel.cs</DependentUpon>
+    </Compile>
+    <Compile Include="ParticlePanels\EditGlowsPanel.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="ParticlePanels\EditGlowsPanel.Designer.cs">
+      <DependentUpon>EditGlowsPanel.cs</DependentUpon>
+    </Compile>
+    <Compile Include="ParticlePanels\EditLightningsPanel.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="ParticlePanels\EditLightningsPanel.Designer.cs">
+      <DependentUpon>EditLightningsPanel.cs</DependentUpon>
+    </Compile>
+    <Compile Include="ParticlePanels\EditRibbonsPanel.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="ParticlePanels\EditRibbonsPanel.Designer.cs">
+      <DependentUpon>EditRibbonsPanel.cs</DependentUpon>
+    </Compile>
+    <Compile Include="ParticlePanels\EditParticlesPanel.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="ParticlePanels\EditParticlesPanel.Designer.cs">
+      <DependentUpon>EditParticlesPanel.cs</DependentUpon>
+    </Compile>
+    <Compile Include="ParticlePanels\MainParticlesPanel.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="ParticlePanels\MainParticlesPanel.Designer.cs">
+      <DependentUpon>MainParticlesPanel.cs</DependentUpon>
+    </Compile>
     <Compile Include="RenameForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -390,6 +438,30 @@
     <EmbeddedResource Include="MainForm.resx">
       <DependentUpon>MainForm.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="ParticlePanels\EditPanelBase.resx">
+      <DependentUpon>EditPanelBase.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ParticlePanels\EditBlastRingsPanel.resx">
+      <DependentUpon>EditBlastRingsPanel.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ParticlePanels\EditFlashesPanel.resx">
+      <DependentUpon>EditFlashesPanel.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ParticlePanels\EditGlowsPanel.resx">
+      <DependentUpon>EditGlowsPanel.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ParticlePanels\EditLightningsPanel.resx">
+      <DependentUpon>EditLightningsPanel.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ParticlePanels\EditRibbonsPanel.resx">
+      <DependentUpon>EditRibbonsPanel.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ParticlePanels\EditParticlesPanel.resx">
+      <DependentUpon>EditParticlesPanel.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ParticlePanels\MainParticlesPanel.resx">
+      <DependentUpon>MainParticlesPanel.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="RenameForm.resx">
       <DependentUpon>RenameForm.cs</DependentUpon>
     </EmbeddedResource>
@@ -446,5 +518,6 @@
   <ItemGroup>
     <Content Include="MindSymbol.ico" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Recombobulator/SR1Structures/Collections/SR1_PointerArray.cs
+++ b/Recombobulator/SR1Structures/Collections/SR1_PointerArray.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	abstract class SR1_PointerArray : SR1_StructureArrayBase<SR1_PointerBase>
+	public abstract class SR1_PointerArray : SR1_StructureArrayBase<SR1_PointerBase>
 	{
 		public SR1_PointerArray(params int[] dimensions)
 			: base(dimensions)
@@ -12,7 +12,7 @@ namespace Recombobulator.SR1Structures
 		}
 	}
 
-	class SR1_PointerArray<T> : SR1_PointerArray where T : SR1_Structure, new()
+	public class SR1_PointerArray<T> : SR1_PointerArray where T : SR1_Structure, new()
 	{
 		private bool _ShouldCreate = false;
 		private int _EntryPadding = 0;

--- a/Recombobulator/SR1Structures/Collections/SR1_PrimativeArray.cs
+++ b/Recombobulator/SR1Structures/Collections/SR1_PrimativeArray.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class SR1_PrimativeArray<T> : SR1_PrimativeBase, IReadOnlyList<T> // where T : struct
+	public class SR1_PrimativeArray<T> : SR1_PrimativeBase, IReadOnlyList<T> // where T : struct
 	{
 		protected int[] _dimensions = null;
 		protected T[] _array = null;

--- a/Recombobulator/SR1Structures/Collections/SR1_String.cs
+++ b/Recombobulator/SR1Structures/Collections/SR1_String.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class SR1_String : SR1_PrimativeArray<char>
+	public class SR1_String : SR1_PrimativeArray<char>
 	{
 		bool _readMax = false;
 

--- a/Recombobulator/SR1Structures/Collections/SR1_StructureArray.cs
+++ b/Recombobulator/SR1Structures/Collections/SR1_StructureArray.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	abstract class SR1_StructureArray : SR1_StructureArrayBase<SR1_Structure>
+	public abstract class SR1_StructureArray : SR1_StructureArrayBase<SR1_Structure>
 	{
 		public SR1_StructureArray(params int[] dimensions)
 			: base(dimensions)
@@ -12,7 +12,7 @@ namespace Recombobulator.SR1Structures
 		}
 	}
 
-	class SR1_StructureArray<T> : SR1_StructureArray where T : SR1_Structure, new()
+	public class SR1_StructureArray<T> : SR1_StructureArray where T : SR1_Structure, new()
 	{
 		public SR1_StructureArray(params int[] dimensions)
 			: base(dimensions)

--- a/Recombobulator/SR1Structures/Collections/SR1_StructureArrayBase.cs
+++ b/Recombobulator/SR1Structures/Collections/SR1_StructureArrayBase.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	abstract class SR1_StructureArrayBase<T> : SR1_Structure, IReadOnlyList<T> where T : SR1_Structure
+	public abstract class SR1_StructureArrayBase<T> : SR1_Structure, IReadOnlyList<T> where T : SR1_Structure
 	{
 		protected int[] _dimensions = null;
 		protected T[] _array = null;

--- a/Recombobulator/SR1Structures/Collections/SR1_StructureList.cs
+++ b/Recombobulator/SR1Structures/Collections/SR1_StructureList.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class SR1_StructureList<T> : SR1_Structure, IReadOnlyList<SR1_Structure> where T : SR1_Structure
+	public class SR1_StructureList<T> : SR1_Structure, IReadOnlyList<SR1_Structure> where T : SR1_Structure
 	{
 		protected List<SR1_Structure> _List = new List<SR1_Structure>();
 

--- a/Recombobulator/SR1Structures/Collections/SR1_StructureSeries.cs
+++ b/Recombobulator/SR1Structures/Collections/SR1_StructureSeries.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
+﻿using System;
 
 namespace Recombobulator.SR1Structures
 {
@@ -9,31 +8,127 @@ namespace Recombobulator.SR1Structures
 
 	class SR1_StructureSeries<T> : SR1_StructureSeries where T : SR1_Structure, new()
 	{
+		protected bool _UseBufferLength;
 		protected int _BufferLength;
+
+		public SR1_StructureSeries()
+		{
+		}
 
 		public SR1_StructureSeries(int bufferLength)
 		{
+			_UseBufferLength = true;
 			_BufferLength = bufferLength;
+		}
+
+		public void Add(T entry)
+		{
+			_List.Add(entry);
+		}
+
+		public void InsertAt(int index, T entry)
+		{
+			_List.Insert(index, entry);
+		}
+
+		public void RemoveAt(T entry)
+		{
+			_List.Remove(entry);
+		}
+
+		public void RemoveAt(int index)
+		{
+			_List.RemoveAt(index);
+		}
+
+		protected T CreateReplacementObject(SR1_Reader reader, in T original)
+		{
+			Type type = original.GetType();
+			T temp = new T();
+			T replacement = new T();
+			long oldPosition = reader.BaseStream.Position;
+
+			if (type == typeof(EventBasicObject))
+			{
+				EventBasicObject tempEBO = new EventBasicObject();
+				tempEBO.ReadTemp(reader);
+				temp = (T)tempEBO.CreateReplacementObject();
+				replacement = (T)tempEBO.CreateReplacementObject();
+			}
+			else if (type == typeof(ObjectSound))
+			{
+				ObjectSound tempOS = new ObjectSound();
+				tempOS.ReadTemp(reader);
+				temp = (T)tempOS.CreateReplacementObject();
+				replacement = (T)tempOS.CreateReplacementObject();
+			}
+			else if (type == typeof(PhysObProperties))
+			{
+				PhysObProperties tempPOP = new PhysObProperties();
+				tempPOP.ReadTemp(reader);
+				temp = (T)tempPOP.CreateReplacementObject();
+				replacement = (T)tempPOP.CreateReplacementObject();
+			}
+			else if (type == typeof(VMObject))
+			{
+				VMObject tempVMO = new VMObject();
+				tempVMO.ReadTemp(reader);
+				temp = (T)tempVMO.CreateReplacementObject();
+				replacement = (T)tempVMO.CreateReplacementObject();
+			}
+
+			reader.BaseStream.Position = oldPosition;
+			temp.ReadTemp(reader);
+
+			// Don't reset to old position after reading temp.
+			// reader.BaseStream.Position will be used to tell whether
+			// it fits in the buffer.
+
+			return replacement;
 		}
 
 		protected override void ReadMembers(SR1_Reader reader, SR1_Structure parent)
 		{
 			long endPosition = reader.BaseStream.Position + _BufferLength;
-			for (int i = 0; reader.BaseStream.Position < endPosition; i++)
-			{
-				T tempEntry = new T();
-				long oldPosition = reader.BaseStream.Position;
-				tempEntry.ReadTemp(reader);
-				reader.BaseStream.Position = oldPosition;
+			int i = 0;
 
-				if (tempEntry.End > endPosition)
+			if (_UseBufferLength)
+			{
+				_List.Clear();
+			}
+
+			while (true)
+			{
+				if (_UseBufferLength &&
+					reader.BaseStream.Position >= endPosition)
 				{
 					break;
 				}
 
-				T newEntry = new T();
+				long oldPosition = reader.BaseStream.Position;
+				T tempEntry = (_UseBufferLength) ? new T() : (T)_List[i];
+				T newEntry = CreateReplacementObject(reader, in tempEntry);
+
+				if (_UseBufferLength &&
+					reader.BaseStream.Position > endPosition)
+				{
+					reader.BaseStream.Position = oldPosition;
+					break;
+				}
+
+				reader.BaseStream.Position = oldPosition;
 				newEntry.Read(reader, this, "[" + i.ToString() + "]");
-				_List.Add(newEntry);
+
+				if (_UseBufferLength)
+				{
+					_List.Add(newEntry);
+				}
+				else
+				{
+					_List[i] = newEntry;
+				}
+
+				i++;
 			}
 		}
 

--- a/Recombobulator/SR1Structures/Exported/Animation/G2AnimFxHeader_Type.cs
+++ b/Recombobulator/SR1Structures/Exported/Animation/G2AnimFxHeader_Type.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class G2AnimFxHeader_Type : SR1_Structure
+	public class G2AnimFxHeader_Type : SR1_Structure
 	{
 		public readonly SR1_Primative<byte> sizeAndSection = new SR1_Primative<byte>();
 		public readonly SR1_Primative<sbyte> type = new SR1_Primative<sbyte>();

--- a/Recombobulator/SR1Structures/Exported/Animation/G2AnimKeylist_Type.cs
+++ b/Recombobulator/SR1Structures/Exported/Animation/G2AnimKeylist_Type.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class G2AnimKeylist_Type : SR1_Structure
+	public class G2AnimKeylist_Type : SR1_Structure
 	{
 		struct G2AnimSegKeyflagInfo_Type
 		{

--- a/Recombobulator/SR1Structures/Exported/CameraKey.cs
+++ b/Recombobulator/SR1Structures/Exported/CameraKey.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class CameraKey : SR1_Structure
+	public class CameraKey : SR1_Structure
 	{
 		SR1_Primative<short> x = new SR1_Primative<short>();
 		SR1_Primative<short> y = new SR1_Primative<short>();

--- a/Recombobulator/SR1Structures/Exported/Event/Event.cs
+++ b/Recombobulator/SR1Structures/Exported/Event/Event.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class Event : SR1_Structure
+	public class Event : SR1_Structure
 	{
 		public SR1_Primative<short> eventNumber = new SR1_Primative<short>();
 		public SR1_Primative<short> numInstances = new SR1_Primative<short>();

--- a/Recombobulator/SR1Structures/Exported/Event/EventBaseObject.cs
+++ b/Recombobulator/SR1Structures/Exported/Event/EventBaseObject.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	abstract class EventBaseObject : SR1_Structure
+	public abstract class EventBaseObject : SR1_Structure
 	{
 		public SR1_Primative<short> id = new SR1_Primative<short>();
 	}

--- a/Recombobulator/SR1Structures/Exported/Event/EventBasicObject.cs
+++ b/Recombobulator/SR1Structures/Exported/Event/EventBasicObject.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class EventBasicObject : EventBaseObject
+	public class EventBasicObject : EventBaseObject
 	{
 		// Inherited SR1_Primative<short> id = new SR1_Primative<short>();
 		SR1_Primative<short> pad = new SR1_Primative<short>();

--- a/Recombobulator/SR1Structures/Exported/Event/EventPointers.cs
+++ b/Recombobulator/SR1Structures/Exported/Event/EventPointers.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class EventPointers : SR1_Structure
+	public class EventPointers : SR1_Structure
 	{
 		public SR1_Primative<int> numPuzzles = new SR1_Primative<int>();
 		public SR1_PointerArray<Event> eventInstances = new SR1_PointerArray<Event>(0, false);

--- a/Recombobulator/SR1Structures/Exported/Event/Events.cs
+++ b/Recombobulator/SR1Structures/Exported/Event/Events.cs
@@ -1,6 +1,6 @@
 ﻿namespace Recombobulator.SR1Structures
 {
-	class Events : SR1_Structure
+	public class Events : SR1_Structure
 	{
 		public SR1_StructureArray<Event> events = new SR1_StructureArray<Event>(0);
 		public EventPointers eventPointers = new EventPointers();

--- a/Recombobulator/SR1Structures/Exported/GenericFX/GenericBlastRingParams.cs
+++ b/Recombobulator/SR1Structures/Exported/GenericFX/GenericBlastRingParams.cs
@@ -27,8 +27,8 @@ namespace Recombobulator.SR1Structures
 		SR1_Primative<short> height2 = new SR1_Primative<short>();
 		SR1_Primative<short> height3 = new SR1_Primative<short>();
 		SR1_Primative<short> predator_offset = new SR1_Primative<short>();
-		SR1_Primative<int> startColor = new SR1_Primative<int>();
-		SR1_Primative<int> endColor = new SR1_Primative<int>();
+		SR1_Primative<int> startColor = new SR1_Primative<int>().ShowAsHex(true);
+		SR1_Primative<int> endColor = new SR1_Primative<int>().ShowAsHex(true);
 
 		protected override void ReadMembers(SR1_Reader reader, SR1_Structure parent)
 		{
@@ -130,6 +130,34 @@ namespace Recombobulator.SR1Structures
 				startColor.Write(writer);
 				endColor.Write(writer);
 			}
+		}
+
+		public static void Copy(GenericBlastRingParams to, GenericBlastRingParams from)
+		{
+			to.type.Value = from.type.Value;
+			to.type_b.Value = from.type_b.Value;
+			to.use_child.Value = from.use_child.Value;
+			to.lifeTime.Value = from.lifeTime.Value;
+			Position.Copy(to.offset, from.offset);
+			SVector.Copy(to.offset_b, from.offset_b);
+			to.matrixSeg.Value = from.matrixSeg.Value;
+			to.segment.Value = from.segment.Value;
+			to.segment_b.Value = from.segment_b.Value;
+			to.sortInWorld.Value = from.sortInWorld.Value;
+			to.sortInWorld_b.Value = from.sortInWorld_b.Value;
+			to.radius.Value = from.radius.Value;
+			to.size1.Value = from.size1.Value;
+			to.size2.Value = from.size2.Value;
+			to.endRadius.Value = from.endRadius.Value;
+			to.colorchange_radius.Value = from.colorchange_radius.Value;
+			to.vel.Value = from.vel.Value;
+			to.accl.Value = from.accl.Value;
+			to.height1.Value = from.height1.Value;
+			to.height2.Value = from.height2.Value;
+			to.height3.Value = from.height3.Value;
+			to.predator_offset.Value = from.predator_offset.Value;
+			to.startColor.Value = from.startColor.Value;
+			to.endColor.Value = from.endColor.Value;
 		}
 	}
 }

--- a/Recombobulator/SR1Structures/Exported/GenericFX/GenericFXObject.cs
+++ b/Recombobulator/SR1Structures/Exported/GenericFX/GenericFXObject.cs
@@ -5,13 +5,13 @@ namespace Recombobulator.SR1Structures
 {
 	class GenericFXObject : SR1_Structure
 	{
-		SR1_Pointer<GenericParticleParams> ParticleList = new SR1_Pointer<GenericParticleParams>();
-		SR1_Pointer<GenericRibbonParams> RibbonList = new SR1_Pointer<GenericRibbonParams>();
-		SR1_Pointer<GenericGlowParams> GlowList = new SR1_Pointer<GenericGlowParams>();
-		SR1_Pointer<GenericLightningParams> LightningList = new SR1_Pointer<GenericLightningParams>();
-		SR1_Pointer<GenericBlastRingParams> BlastList = new SR1_Pointer<GenericBlastRingParams>();
-		SR1_Pointer<GenericFlashParams> FlashList = new SR1_Pointer<GenericFlashParams>();
-		SR1_PrimativePointer<int> ColorList = new SR1_PrimativePointer<int>();
+        public readonly SR1_Pointer<GenericParticleParams> ParticleList = new SR1_Pointer<GenericParticleParams>();
+        public readonly SR1_Pointer<GenericRibbonParams> RibbonList = new SR1_Pointer<GenericRibbonParams>();
+        public readonly SR1_Pointer<GenericGlowParams> GlowList = new SR1_Pointer<GenericGlowParams>();
+        public readonly SR1_Pointer<GenericLightningParams> LightningList = new SR1_Pointer<GenericLightningParams>();
+        public readonly SR1_Pointer<GenericBlastRingParams> BlastList = new SR1_Pointer<GenericBlastRingParams>();
+        public readonly SR1_Pointer<GenericFlashParams> FlashList = new SR1_Pointer<GenericFlashParams>();
+        public readonly SR1_PrimativePointer<int> ColorList = new SR1_PrimativePointer<int>();
 
 		protected override void ReadMembers(SR1_Reader reader, SR1_Structure parent)
 		{

--- a/Recombobulator/SR1Structures/Exported/GenericFX/GenericFlashParams.cs
+++ b/Recombobulator/SR1Structures/Exported/GenericFX/GenericFlashParams.cs
@@ -7,7 +7,7 @@ namespace Recombobulator.SR1Structures
 	{
 		SR1_Primative<short> type = new SR1_Primative<short>();
 		SR1_Primative<short> timeToColor = new SR1_Primative<short>();
-		SR1_Primative<int> color = new SR1_Primative<int>();
+		SR1_Primative<int> color = new SR1_Primative<int>().ShowAsHex(true);
 		SR1_Primative<short> timeAtColor = new SR1_Primative<short>();
 		SR1_Primative<short> timeFromColor = new SR1_Primative<short>();
 
@@ -31,6 +31,15 @@ namespace Recombobulator.SR1Structures
 			color.Write(writer);
 			timeAtColor.Write(writer);
 			timeFromColor.Write(writer);
+		}
+
+		public static void Copy(GenericFlashParams to, GenericFlashParams from)
+		{
+			to.type.Value = from.type.Value;
+			to.timeToColor.Value = from.timeToColor.Value;
+			to.color.Value = from.color.Value;
+			to.timeAtColor.Value = from.timeAtColor.Value;
+			to.timeFromColor.Value = from.timeFromColor.Value;
 		}
 	}
 }

--- a/Recombobulator/SR1Structures/Exported/GenericFX/GenericGlowParams.cs
+++ b/Recombobulator/SR1Structures/Exported/GenericFX/GenericGlowParams.cs
@@ -102,5 +102,27 @@ namespace Recombobulator.SR1Structures
 				fadeout_time.Write(writer);
 			}
 		}
+
+		public static void Copy(GenericGlowParams to, GenericGlowParams from)
+		{
+			to.StartOnInit.Value = from.StartOnInit.Value;
+			to.StartOnInit_b.Value = from.StartOnInit_b.Value;
+			to.segment.Value = from.segment.Value;
+			to.segmentEnd.Value = from.segmentEnd.Value;
+			to.numSegments.Value = from.numSegments.Value;
+			to.numSegments_b.Value = from.numSegments_b.Value;
+			to.color_num.Value = from.color_num.Value;
+			to.use_child.Value = from.use_child.Value;
+			to.numColors.Value = from.numColors.Value;
+			to.numColors_b.Value = from.numColors_b.Value;
+			to.id.Value = from.id.Value;
+			to.id_b.Value = from.id_b.Value;
+			to.atuColorCycleRate.Value = from.atuColorCycleRate.Value;
+			to.width.Value = from.width.Value;
+			to.height.Value = from.height.Value;
+			to.lifetime.Value = from.lifetime.Value;
+			to.fadein_time.Value = from.fadein_time.Value;
+			to.fadeout_time.Value = from.fadeout_time.Value;
+		}
 	}
 }

--- a/Recombobulator/SR1Structures/Exported/GenericFX/GenericLightningParams.cs
+++ b/Recombobulator/SR1Structures/Exported/GenericFX/GenericLightningParams.cs
@@ -25,8 +25,8 @@ namespace Recombobulator.SR1Structures
 		SR1_Primative<short> small_width = new SR1_Primative<short>();
 		SR1_Primative<short> sine_size = new SR1_Primative<short>();
 		SR1_Primative<short> variation = new SR1_Primative<short>();
-		SR1_Primative<int> color = new SR1_Primative<int>();
-		SR1_Primative<int> glow_color = new SR1_Primative<int>();
+		SR1_Primative<int> color = new SR1_Primative<int>().ShowAsHex(true);
+		SR1_Primative<int> glow_color = new SR1_Primative<int>().ShowAsHex(true);
 
 		protected override void ReadMembers(SR1_Reader reader, SR1_Structure parent)
 		{
@@ -116,6 +116,32 @@ namespace Recombobulator.SR1Structures
 				color.Write(writer);
 				glow_color.Write(writer);
 			}
+		}
+
+		public static void Copy(GenericLightningParams to, GenericLightningParams from)
+		{
+			to.type.Value = from.type.Value;
+			to.type_b.Value = from.type_b.Value;
+			to.use_child.Value = from.use_child.Value;
+			to.lifeTime.Value = from.lifeTime.Value;
+			to.deg.Value = from.deg.Value;
+			to.deg_inc.Value = from.deg_inc.Value;
+			Position.Copy(to.start_offset, from.start_offset);
+			to.startSeg.Value = from.startSeg.Value;
+			to.startSeg_b.Value = from.startSeg_b.Value;
+			to.endSeg.Value = from.endSeg.Value;
+			to.endSeg_b.Value = from.endSeg_b.Value;
+			Position.Copy(to.end_offset, from.end_offset);
+			to.matrixSeg.Value = from.matrixSeg.Value;
+			to.matrixSeg_b.Value = from.matrixSeg_b.Value;
+			to.segs.Value = from.segs.Value;
+			to.segs_b.Value = from.segs_b.Value;
+			to.width.Value = from.width.Value;
+			to.small_width.Value = from.small_width.Value;
+			to.sine_size.Value = from.sine_size.Value;
+			to.variation.Value = from.variation.Value;
+			to.color.Value = from.color.Value;
+			to.glow_color.Value = from.glow_color.Value;
 		}
 	}
 }

--- a/Recombobulator/SR1Structures/Exported/GenericFX/GenericParticleParams.cs
+++ b/Recombobulator/SR1Structures/Exported/GenericFX/GenericParticleParams.cs
@@ -5,45 +5,45 @@ namespace Recombobulator.SR1Structures
 {
 	class GenericParticleParams : SR1_Structure
 	{
-		SR1_Primative<short> size = new SR1_Primative<short>();
-		SR1_Primative<byte> StartOnInit = new SR1_Primative<byte>();
-		SR1_Primative<byte> type = new SR1_Primative<byte>();
-		SR1_Primative<short> birthRadius = new SR1_Primative<short>();
-		SR1_Primative<sbyte> startSegment = new SR1_Primative<sbyte>();
-		SR1_Primative<sbyte> endSegment = new SR1_Primative<sbyte>();
-		SR1_Primative<short> startSegment_a = new SR1_Primative<short>();
-		Position direction = new Position();
-		SR1_Primative<byte> spectral_colorize = new SR1_Primative<byte>();
-		SR1_Primative<byte> absolute_direction = new SR1_Primative<byte>();
-		Position acceleration = new Position();
-		SR1_Primative<sbyte> accx = new SR1_Primative<sbyte>();
-		SR1_Primative<sbyte> accy = new SR1_Primative<sbyte>();
-		SR1_Primative<sbyte> accz = new SR1_Primative<sbyte>();
-		SR1_Primative<sbyte> useInstanceModel = new SR1_Primative<sbyte>();
-		SR1_Primative<short> useInstanceModel_b = new SR1_Primative<short>();
-		SR1_Primative<int> startColor = new SR1_Primative<int>();
-		SR1_Primative<byte> startColor_red = new SR1_Primative<byte>();
-		SR1_Primative<byte> startColor_green = new SR1_Primative<byte>();
-		SR1_Primative<byte> startColor_blue = new SR1_Primative<byte>();
-		SR1_Primative<sbyte> model = new SR1_Primative<sbyte>();
-		SR1_Primative<short> model_b = new SR1_Primative<short>();
-		SR1_Primative<int> endColor = new SR1_Primative<int>();
-		SR1_Primative<byte> endColor_red = new SR1_Primative<byte>();
-		SR1_Primative<byte> endColor_green = new SR1_Primative<byte>();
-		SR1_Primative<byte> endColor_blue = new SR1_Primative<byte>();
-		SR1_Primative<sbyte> texture = new SR1_Primative<sbyte>();
-		SR1_Primative<short> texture_b = new SR1_Primative<short>();
-		SR1_Primative<short> lifeTime = new SR1_Primative<short>();
-		SR1_Primative<byte> primLifeTime = new SR1_Primative<byte>();
-		SR1_Primative<short> primLifeTime_b = new SR1_Primative<short>();
-		SR1_Primative<sbyte> use_child = new SR1_Primative<sbyte>();
-		SR1_Primative<short> startFadeValue = new SR1_Primative<short>();
-		SR1_Primative<short> fadeStep = new SR1_Primative<short>();
-		SR1_Primative<sbyte> numberBirthParticles = new SR1_Primative<sbyte>();
-		SR1_Primative<sbyte> z_undulation_mode = new SR1_Primative<sbyte>();
-		SR1_Primative<short> scaleSpeed = new SR1_Primative<short>();
-		Position offset = new Position();
-		SR1_Primative<short> startScale = new SR1_Primative<short>();
+        public readonly SR1_Primative<short> size = new SR1_Primative<short>();
+        public readonly SR1_Primative<byte> StartOnInit = new SR1_Primative<byte>();
+        public readonly SR1_Primative<byte> type = new SR1_Primative<byte>();
+		public readonly SR1_Primative<short> birthRadius = new SR1_Primative<short>();
+		public readonly SR1_Primative<sbyte> startSegment = new SR1_Primative<sbyte>();
+		public readonly SR1_Primative<sbyte> endSegment = new SR1_Primative<sbyte>();
+		public readonly SR1_Primative<short> startSegment_a = new SR1_Primative<short>();
+        public readonly Position direction = new Position();
+        public readonly SR1_Primative<byte> spectral_colorize = new SR1_Primative<byte>();
+        public readonly SR1_Primative<byte> absolute_direction = new SR1_Primative<byte>();
+        public readonly Position acceleration = new Position();
+        public readonly SR1_Primative<sbyte> accx = new SR1_Primative<sbyte>();
+        public readonly SR1_Primative<sbyte> accy = new SR1_Primative<sbyte>();
+        public readonly SR1_Primative<sbyte> accz = new SR1_Primative<sbyte>();
+        public readonly SR1_Primative<sbyte> useInstanceModel = new SR1_Primative<sbyte>();
+        public readonly SR1_Primative<short> useInstanceModel_b = new SR1_Primative<short>();
+        public readonly SR1_Primative<int> startColor = new SR1_Primative<int>();
+        public readonly SR1_Primative<byte> startColor_red = new SR1_Primative<byte>();
+        public readonly SR1_Primative<byte> startColor_green = new SR1_Primative<byte>();
+        public readonly SR1_Primative<byte> startColor_blue = new SR1_Primative<byte>();
+        public readonly SR1_Primative<sbyte> model = new SR1_Primative<sbyte>();
+        public readonly SR1_Primative<short> model_b = new SR1_Primative<short>();
+        public readonly SR1_Primative<int> endColor = new SR1_Primative<int>();
+        public readonly SR1_Primative<byte> endColor_red = new SR1_Primative<byte>();
+        public readonly SR1_Primative<byte> endColor_green = new SR1_Primative<byte>();
+        public readonly SR1_Primative<byte> endColor_blue = new SR1_Primative<byte>();
+        public readonly SR1_Primative<sbyte> texture = new SR1_Primative<sbyte>();
+        public readonly SR1_Primative<short> texture_b = new SR1_Primative<short>();
+        public readonly SR1_Primative<short> lifeTime = new SR1_Primative<short>();
+        public readonly SR1_Primative<byte> primLifeTime = new SR1_Primative<byte>();
+        public readonly SR1_Primative<short> primLifeTime_b = new SR1_Primative<short>();
+        public readonly SR1_Primative<sbyte> use_child = new SR1_Primative<sbyte>();
+        public readonly SR1_Primative<short> startFadeValue = new SR1_Primative<short>();
+        public readonly SR1_Primative<short> fadeStep = new SR1_Primative<short>();
+        public readonly SR1_Primative<sbyte> numberBirthParticles = new SR1_Primative<sbyte>();
+        public readonly SR1_Primative<sbyte> z_undulation_mode = new SR1_Primative<sbyte>();
+        public readonly SR1_Primative<short> scaleSpeed = new SR1_Primative<short>();
+        public readonly Position offset = new Position();
+        public readonly SR1_Primative<short> startScale = new SR1_Primative<short>();
 
 		protected override void ReadMembers(SR1_Reader reader, SR1_Structure parent)
 		{
@@ -179,6 +179,49 @@ namespace Recombobulator.SR1Structures
 				offset.Write(writer);
 				startScale.Write(writer);
 			}
+		}
+
+		public static void Copy(GenericParticleParams to, GenericParticleParams from)
+		{
+            to.size.Value = from.size.Value;
+            to.StartOnInit.Value = from.StartOnInit.Value;
+            to.type.Value = from.type.Value;
+            to.birthRadius.Value = from.birthRadius.Value;
+            to.startSegment.Value = from.startSegment.Value;
+            to.endSegment.Value = from.endSegment.Value;
+            to.startSegment_a.Value = from.startSegment_a.Value;
+            Position.Copy(to.direction, from.direction);
+            to.spectral_colorize.Value = from.spectral_colorize.Value;
+            to.absolute_direction.Value = from.absolute_direction.Value;
+            Position.Copy(to.acceleration, from.acceleration);
+            to.accx.Value = from.accx.Value;
+            to.accy.Value = from.accy.Value;
+            to.accz.Value = from.accz.Value;
+            to.useInstanceModel.Value = from.useInstanceModel.Value;
+            to.useInstanceModel_b.Value = from.useInstanceModel_b.Value;
+            to.startColor.Value = from.startColor.Value;
+            to.startColor_red.Value = from.startColor_red.Value;
+            to.startColor_green.Value = from.startColor_green.Value;
+            to.startColor_blue.Value = from.startColor_blue.Value;
+            to.model.Value = from.model.Value;
+            to.model_b.Value = from.model_b.Value;
+            to.endColor.Value = from.endColor.Value;
+            to.endColor_red.Value = from.endColor_red.Value;
+            to.endColor_green.Value = from.endColor_green.Value;
+            to.endColor_blue.Value = from.endColor_blue.Value;
+            to.texture.Value = from.texture.Value;
+            to.texture_b.Value = from.texture_b.Value;
+            to.lifeTime.Value = from.lifeTime.Value;
+            to.primLifeTime.Value = from.primLifeTime.Value;
+            to.primLifeTime_b.Value = from.primLifeTime_b.Value;
+            to.use_child.Value = from.use_child.Value;
+            to.startFadeValue.Value = from.startFadeValue.Value;
+            to.fadeStep.Value = from.fadeStep.Value;
+            to.numberBirthParticles.Value = from.numberBirthParticles.Value;
+            to.z_undulation_mode.Value = from.z_undulation_mode.Value;
+            to.scaleSpeed.Value = from.scaleSpeed.Value;
+            Position.Copy(to.offset, from.offset);
+            to.startScale.Value = from.startScale.Value;
 		}
 	}
 }

--- a/Recombobulator/SR1Structures/Exported/GenericFX/GenericRibbonParams.cs
+++ b/Recombobulator/SR1Structures/Exported/GenericFX/GenericRibbonParams.cs
@@ -19,8 +19,8 @@ namespace Recombobulator.SR1Structures
 		SR1_Primative<short> ribbonLifeTime = new SR1_Primative<short>();
 		SR1_Primative<short> faceLifeTime = new SR1_Primative<short>();
 		SR1_Primative<short> startFadeValue = new SR1_Primative<short>();
-		SR1_Primative<int> startColor = new SR1_Primative<int>();
-		SR1_Primative<int> endColor = new SR1_Primative<int>();
+		SR1_Primative<int> startColor = new SR1_Primative<int>().ShowAsHex(true);
+		SR1_Primative<int> endColor = new SR1_Primative<int>().ShowAsHex(true);
 
 		protected override void ReadMembers(SR1_Reader reader, SR1_Structure parent)
 		{
@@ -86,6 +86,26 @@ namespace Recombobulator.SR1Structures
 				startColor.Write(writer);
 				endColor.Write(writer);
 			}
+		}
+
+		public static void Copy(GenericRibbonParams to, GenericRibbonParams from)
+		{
+			to.id.Value = from.id.Value;
+			to.id_b.Value = from.id_b.Value;
+			to.StartOnInit.Value = from.StartOnInit.Value;
+			to.StartOnInit_b.Value = from.StartOnInit_b.Value;
+			to.startSegment.Value = from.startSegment.Value;
+			to.startSegment_b.Value = from.startSegment_b.Value;
+			to.endSegment.Value = from.endSegment.Value;
+			to.endSegment_b.Value = from.endSegment_b.Value;
+			to.type.Value = from.type.Value;
+			to.type_b.Value = from.type_b.Value;
+			to.use_child.Value = from.use_child.Value;
+			to.ribbonLifeTime.Value = from.ribbonLifeTime.Value;
+			to.faceLifeTime.Value = from.faceLifeTime.Value;
+			to.startFadeValue.Value = from.startFadeValue.Value;
+			to.startColor.Value = from.startColor.Value;
+			to.endColor.Value = from.endColor.Value;
 		}
 	}
 }

--- a/Recombobulator/SR1Structures/Exported/Geometry/Face.cs
+++ b/Recombobulator/SR1Structures/Exported/Geometry/Face.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class Face : SR1_Structure
+	public class Face : SR1_Structure
 	{
 		SR1_Primative<ushort> v0 = new SR1_Primative<ushort>();
 		SR1_Primative<ushort> v1 = new SR1_Primative<ushort>();

--- a/Recombobulator/SR1Structures/Exported/Geometry/Position.cs
+++ b/Recombobulator/SR1Structures/Exported/Geometry/Position.cs
@@ -3,11 +3,11 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class Position : SR1_Structure
+	public class Position : SR1_Structure
 	{
-		SR1_Primative<short> x = new SR1_Primative<short>();
-		SR1_Primative<short> y = new SR1_Primative<short>();
-		SR1_Primative<short> z = new SR1_Primative<short>();
+		public readonly SR1_Primative<short> x = new SR1_Primative<short>();
+		public readonly SR1_Primative<short> y = new SR1_Primative<short>();
+		public readonly SR1_Primative<short> z = new SR1_Primative<short>();
 
 		protected override void ReadMembers(SR1_Reader reader, SR1_Structure parent)
 		{
@@ -25,6 +25,18 @@ namespace Recombobulator.SR1Structures
 			x.Write(writer);
 			y.Write(writer);
 			z.Write(writer);
+		}
+
+		public static void Copy(Position to, Position from)
+		{
+			to.x.Value = from.x.Value;
+			to.y.Value = from.y.Value;
+			to.z.Value = from.z.Value;
+		}
+
+		public override string ToString()
+		{
+			return "{ x = " + x + ", y = " + y + ", z = " + z + " }";
 		}
 	}
 }

--- a/Recombobulator/SR1Structures/Exported/Geometry/Rotation.cs
+++ b/Recombobulator/SR1Structures/Exported/Geometry/Rotation.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class Rotation : SR1_Structure
+	public class Rotation : SR1_Structure
 	{
 		SR1_Primative<short> x = new SR1_Primative<short>();
 		SR1_Primative<short> y = new SR1_Primative<short>();

--- a/Recombobulator/SR1Structures/Exported/Geometry/SVector.cs
+++ b/Recombobulator/SR1Structures/Exported/Geometry/SVector.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class SVector : SR1_Structure
+	public class SVector : SR1_Structure
 	{
 		public readonly SR1_Primative<short> x = new SR1_Primative<short>();
 		public readonly SR1_Primative<short> y = new SR1_Primative<short>();
@@ -35,6 +35,13 @@ namespace Recombobulator.SR1Structures
 			y.Write(writer);
 			z.Write(writer);
 			pad.Write(writer);
+		}
+
+		public static void Copy(SVector to, SVector from)
+		{
+			to.x.Value = from.x.Value;
+			to.y.Value = from.y.Value;
+			to.z.Value = from.z.Value;
 		}
 
 		public override string ToString()

--- a/Recombobulator/SR1Structures/Exported/Geometry/SVectorNoPad.cs
+++ b/Recombobulator/SR1Structures/Exported/Geometry/SVectorNoPad.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class SVectorNoPad : SR1_Structure
+	public class SVectorNoPad : SR1_Structure
 	{
 		SR1_Primative<short> x = new SR1_Primative<short>();
 		SR1_Primative<short> y = new SR1_Primative<short>();

--- a/Recombobulator/SR1Structures/Exported/Geometry/VGroup.cs
+++ b/Recombobulator/SR1Structures/Exported/Geometry/VGroup.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class VGroup : SR1_Structure
+	public class VGroup : SR1_Structure
 	{
 		SR1_Primative<int> id = new SR1_Primative<int>();
 		SR1_Primative<int> numVertices = new SR1_Primative<int>();

--- a/Recombobulator/SR1Structures/Exported/INICommand.cs
+++ b/Recombobulator/SR1Structures/Exported/INICommand.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class INICommand : SR1_Structure
+	public class INICommand : SR1_Structure
 	{
 		public readonly INICommandType command = new INICommandType();
 		SR1_Primative<short> numParameters = new SR1_Primative<short>();

--- a/Recombobulator/SR1Structures/Exported/INICommandType.cs
+++ b/Recombobulator/SR1Structures/Exported/INICommandType.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class INICommandType : SR1_Primative<short>
+	public class INICommandType : SR1_Primative<short>
 	{
 		public INICommandType()
 			: base()

--- a/Recombobulator/SR1Structures/Exported/Intro.cs
+++ b/Recombobulator/SR1Structures/Exported/Intro.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class Intro : SR1_Structure
+	public class Intro : SR1_Structure
 	{
 		public readonly SR1_String name = new SR1_String(16);
 		public readonly SR1_Primative<int> intronum = new SR1_Primative<int>();

--- a/Recombobulator/SR1Structures/Exported/Level.cs
+++ b/Recombobulator/SR1Structures/Exported/Level.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class Level : SR1_Structure
+	public class Level : SR1_Structure
 	{
 		// Use      //.*\r?\n     to search and remove comments.
 

--- a/Recombobulator/SR1Structures/Exported/LightGroup.cs
+++ b/Recombobulator/SR1Structures/Exported/LightGroup.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class LightGroup : SR1_Structure
+	public class LightGroup : SR1_Structure
 	{
 		Matrix lightMatrix = new Matrix();
 		Matrix colorMatrix = new Matrix();

--- a/Recombobulator/SR1Structures/Exported/LightList.cs
+++ b/Recombobulator/SR1Structures/Exported/LightList.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class LightList : SR1_Structure
+	public class LightList : SR1_Structure
 	{
 		CVector ambient = new CVector();
 		SR1_Primative<int> numLightGroups = new SR1_Primative<int>();

--- a/Recombobulator/SR1Structures/Exported/Model/MFace.cs
+++ b/Recombobulator/SR1Structures/Exported/Model/MFace.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class MFace : SR1_Structure
+	public class MFace : SR1_Structure
 	{
 		public readonly Face face = new Face();
 		public readonly SR1_Primative<byte> normal = new SR1_Primative<byte>();

--- a/Recombobulator/SR1Structures/Exported/Model/MVertex.cs
+++ b/Recombobulator/SR1Structures/Exported/Model/MVertex.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class MVertex : SR1_Structure
+	public class MVertex : SR1_Structure
 	{
 		Vertex vertex = new Vertex();
 		SR1_Primative<ushort> normal = new SR1_Primative<ushort>();

--- a/Recombobulator/SR1Structures/Exported/Model/Model.cs
+++ b/Recombobulator/SR1Structures/Exported/Model/Model.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class Model : SR1_Structure
+	public class Model : SR1_Structure
 	{
 		public readonly SR1_Primative<int> numVertices = new SR1_Primative<int>();
 		public readonly SR1_Pointer<MVertex> vertexList = new SR1_Pointer<MVertex>();

--- a/Recombobulator/SR1Structures/Exported/Model/Segment.cs
+++ b/Recombobulator/SR1Structures/Exported/Model/Segment.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class Segment : SR1_Structure
+	public class Segment : SR1_Structure
 	{
 		SR1_Primative<int> flags = new SR1_Primative<int>();
 		SR1_Primative<short> firstTri = new SR1_Primative<short>();

--- a/Recombobulator/SR1Structures/Exported/Monster/MonsterAllegiances.cs
+++ b/Recombobulator/SR1Structures/Exported/Monster/MonsterAllegiances.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class MonsterAllegiances : SR1_Structure
+	public class MonsterAllegiances : SR1_Structure
 	{
 		SR1_Primative<uint> enemies = new SR1_Primative<uint>();
 		SR1_Primative<uint> allies = new SR1_Primative<uint>();

--- a/Recombobulator/SR1Structures/Exported/Monster/MonsterCombatAttributes.cs
+++ b/Recombobulator/SR1Structures/Exported/Monster/MonsterCombatAttributes.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class MonsterCombatAttributes : SR1_Structure
+	public class MonsterCombatAttributes : SR1_Structure
 	{
 		SR1_Primative<short> stunTime = new SR1_Primative<short>();
 		SR1_Primative<short> damageTime = new SR1_Primative<short>();

--- a/Recombobulator/SR1Structures/Exported/Monster/MonsterSenses.cs
+++ b/Recombobulator/SR1Structures/Exported/Monster/MonsterSenses.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class MonsterSenses : SR1_Structure
+	public class MonsterSenses : SR1_Structure
 	{
 		SR1_Primative<short> sightArc = new SR1_Primative<short>();
 		SR1_Primative<short> sightRadius = new SR1_Primative<short>();

--- a/Recombobulator/SR1Structures/Exported/Monster/MonsterSubAttributes.cs
+++ b/Recombobulator/SR1Structures/Exported/Monster/MonsterSubAttributes.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class MonsterSubAttributes : SR1_Structure
+	public class MonsterSubAttributes : SR1_Structure
 	{
 		public readonly SR1_PrimativePointer<sbyte> animList = new SR1_PrimativePointer<sbyte>();
 		public readonly SR1_Pointer<MonsterSenses> senses = new SR1_Pointer<MonsterSenses>();

--- a/Recombobulator/SR1Structures/Exported/Monster/RelocateList.cs
+++ b/Recombobulator/SR1Structures/Exported/Monster/RelocateList.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class RelocateList : SR1_Structure
+	public class RelocateList : SR1_Structure
 	{
 		SR1_PrimativeArray<int> unknown = new SR1_PrimativeArray<int>();
 

--- a/Recombobulator/SR1Structures/Exported/Object.cs
+++ b/Recombobulator/SR1Structures/Exported/Object.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class Object : SR1_Structure
+	public class Object : SR1_Structure
 	{
 		private enum ScriptType
 		{

--- a/Recombobulator/SR1Structures/Exported/ObjectEffect.cs
+++ b/Recombobulator/SR1Structures/Exported/ObjectEffect.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class ObjectEffect : SR1_Structure
+	public class ObjectEffect : SR1_Structure
 	{
 		SR1_Primative<byte> effectNumber = new SR1_Primative<byte>();
 		SR1_PrimativeArray<byte> modifierList = new SR1_PrimativeArray<byte>(3);

--- a/Recombobulator/SR1Structures/Exported/ObjectNameList.cs
+++ b/Recombobulator/SR1Structures/Exported/ObjectNameList.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class ObjectNameList : SR1_Structure
+	public class ObjectNameList : SR1_Structure
 	{
 		List<SR1_String> _List = new List<SR1_String>();
 		SR1_PrimativePointer<char> listStart = new SR1_PrimativePointer<char>();

--- a/Recombobulator/SR1Structures/Exported/PhysicalObject/PhysObProperties.cs
+++ b/Recombobulator/SR1Structures/Exported/PhysicalObject/PhysObProperties.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class PhysObProperties : SR1_Structure
+	public class PhysObProperties : SR1_Structure
 	{
 		public readonly SR1_Primative<short> version = new SR1_Primative<short>().ShowAsHex(true);
 		public readonly SR1_Primative<short> family = new SR1_Primative<short>();

--- a/Recombobulator/SR1Structures/Exported/PhysicalObject/PhysObPropertiesBase.cs
+++ b/Recombobulator/SR1Structures/Exported/PhysicalObject/PhysObPropertiesBase.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	abstract class PhysObPropertiesBase : SR1_Structure
+	public abstract class PhysObPropertiesBase : SR1_Structure
 	{
 		public readonly PhysObProperties Properties = new PhysObProperties();
 	}

--- a/Recombobulator/SR1Structures/Exported/PlanMkr.cs
+++ b/Recombobulator/SR1Structures/Exported/PlanMkr.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class PlanMkr : SR1_Structure
+	public class PlanMkr : SR1_Structure
 	{
 		Position pos = new Position();
 		SR1_Primative<short> id = new SR1_Primative<short>();

--- a/Recombobulator/SR1Structures/Exported/SFXFileData.cs
+++ b/Recombobulator/SR1Structures/Exported/SFXFileData.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class SFXFileData : SR1_Structure
+	public class SFXFileData : SR1_Structure
 	{
 		SR1_Primative<ushort> type = new SR1_Primative<ushort>();
 		SR1_Primative<ushort> numSounds = new SR1_Primative<ushort>();

--- a/Recombobulator/SR1Structures/Exported/SFXMkr.cs
+++ b/Recombobulator/SR1Structures/Exported/SFXMkr.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class SFXMkr : SR1_Structure
+	public class SFXMkr : SR1_Structure
 	{
 		SR1_Pointer<SFXFileData> soundData = new SR1_Pointer<SFXFileData>();
 		SR1_Primative<int> uniqueID = new SR1_Primative<int>();

--- a/Recombobulator/SR1Structures/Exported/ScriptPCode.cs
+++ b/Recombobulator/SR1Structures/Exported/ScriptPCode.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class ScriptPCode : SR1_Structure
+	public class ScriptPCode : SR1_Structure
 	{
 		public SR1_Primative<ushort> sizeOfPcodeStream = new SR1_Primative<ushort>();
 		public SR1_Primative<ushort> conditionBits = new SR1_Primative<ushort>();

--- a/Recombobulator/SR1Structures/Exported/Signal/MultiSignal.cs
+++ b/Recombobulator/SR1Structures/Exported/Signal/MultiSignal.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class MultiSignal : SR1_Structure
+	public class MultiSignal : SR1_Structure
 	{
 		public readonly SR1_Primative<int> numSignals = new SR1_Primative<int>();
 		public readonly SR1_Primative<short> signalNum = new SR1_Primative<short>();

--- a/Recombobulator/SR1Structures/Exported/Signal/Signal.cs
+++ b/Recombobulator/SR1Structures/Exported/Signal/Signal.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class Signal : SR1_Structure
+	public class Signal : SR1_Structure
 	{
 		public enum SignalTypeJun01
 		{

--- a/Recombobulator/SR1Structures/Exported/Signal/SignalData.cs
+++ b/Recombobulator/SR1Structures/Exported/Signal/SignalData.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class SignalData : SR1_Structure
+	public class SignalData : SR1_Structure
 	{
 		// No members. This is just a base class.
 

--- a/Recombobulator/SR1Structures/Exported/Spline/MultiSpline.cs
+++ b/Recombobulator/SR1Structures/Exported/Spline/MultiSpline.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class MultiSpline : SR1_Structure
+	public class MultiSpline : SR1_Structure
 	{
 		SR1_Pointer<Spline> positional = new SR1_Pointer<Spline>();
 		SR1_Pointer<RSpline> rotational = new SR1_Pointer<RSpline>();

--- a/Recombobulator/SR1Structures/Exported/SpotLight.cs
+++ b/Recombobulator/SR1Structures/Exported/SpotLight.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class SpotLight : SR1_Structure
+	public class SpotLight : SR1_Structure
 	{
 		NodeType node = new NodeType();
 		SR1_Primative<byte> r = new SR1_Primative<byte>();

--- a/Recombobulator/SR1Structures/Exported/StreamUnitPortal.cs
+++ b/Recombobulator/SR1Structures/Exported/StreamUnitPortal.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class StreamUnitPortal : SR1_Structure
+	public class StreamUnitPortal : SR1_Structure
 	{
 		public readonly SR1_String tolevelname = new SR1_String(16);
 		public readonly SR1_Primative<int> MSignalID = new SR1_Primative<int>();

--- a/Recombobulator/SR1Structures/Exported/StreamUnitPortalList.cs
+++ b/Recombobulator/SR1Structures/Exported/StreamUnitPortalList.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class StreamUnitPortalList : SR1_Structure
+	public class StreamUnitPortalList : SR1_Structure
 	{
 		public readonly SR1_Primative<int> numPortals = new SR1_Primative<int>();
 		public readonly SR1_StructureList<StreamUnitPortal> portals = new SR1_StructureList<StreamUnitPortal>();

--- a/Recombobulator/SR1Structures/Exported/TClassAttr.cs
+++ b/Recombobulator/SR1Structures/Exported/TClassAttr.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class TClassAttr : SR1_Structure
+	public class TClassAttr : SR1_Structure
 	{
 		SR1_Primative<short> flags = new SR1_Primative<short>();
 		SR1_Primative<ushort> sound = new SR1_Primative<ushort>();

--- a/Recombobulator/SR1Structures/Exported/Terrain/Terrain.cs
+++ b/Recombobulator/SR1Structures/Exported/Terrain/Terrain.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class Terrain : SR1_Structure
+	public class Terrain : SR1_Structure
 	{
 		// Use      //.*\r?\n     to search and remove comments.
 

--- a/Recombobulator/SR1Structures/Exported/Textures/AniTex.cs
+++ b/Recombobulator/SR1Structures/Exported/Textures/AniTex.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class AniTex : SR1_Structure
+	public class AniTex : SR1_Structure
 	{
 		SR1_Primative<int> numAniTextures = new SR1_Primative<int>();
 		SR1_StructureArray<AniTexInfo> aniTexInfo = new SR1_StructureArray<AniTexInfo>(0);

--- a/Recombobulator/SR1Structures/Exported/Textures/DrMoveAniTex.cs
+++ b/Recombobulator/SR1Structures/Exported/Textures/DrMoveAniTex.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class DrMoveAniTex : SR1_Structure
+	public class DrMoveAniTex : SR1_Structure
 	{
 		SR1_Primative<int> numAniTextures = new SR1_Primative<int>();
 		SR1_PointerArray<DrMoveAniTexDestInfo> aniTexInfo = new SR1_PointerArray<DrMoveAniTexDestInfo>(0, true);

--- a/Recombobulator/SR1Structures/Exported/Textures/TextureMT3.cs
+++ b/Recombobulator/SR1Structures/Exported/Textures/TextureMT3.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class TextureMT3 : SR1_Structure
+	public class TextureMT3 : SR1_Structure
 	{
 		SR1_Primative<byte> u0 = new SR1_Primative<byte>();
 		SR1_Primative<byte> v0 = new SR1_Primative<byte>();

--- a/Recombobulator/SR1Structures/Exported/VMObject/VMObject.cs
+++ b/Recombobulator/SR1Structures/Exported/VMObject/VMObject.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class VMObject : SR1_Structure
+	public class VMObject : SR1_Structure
 	{
 		SR1_Primative<ushort> flags = new SR1_Primative<ushort>();
 

--- a/Recombobulator/SR1Structures/Exported/VramSize.cs
+++ b/Recombobulator/SR1Structures/Exported/VramSize.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class VramSize : SR1_Structure
+	public class VramSize : SR1_Structure
 	{
 		public readonly SR1_Primative<short> x = new SR1_Primative<short>();
 		public readonly SR1_Primative<short> y = new SR1_Primative<short>();

--- a/Recombobulator/SR1Structures/InGame/BGObject.cs
+++ b/Recombobulator/SR1Structures/InGame/BGObject.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class BGObject : SR1_Structure
+	public class BGObject : SR1_Structure
 	{
 		protected override void ReadMembers(SR1_Reader reader, SR1_Structure parent)
 		{

--- a/Recombobulator/SR1Structures/InGame/HotSpot.cs
+++ b/Recombobulator/SR1Structures/InGame/HotSpot.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class HotSpot : SR1_Structure
+	public class HotSpot : SR1_Structure
 	{
 		protected override void ReadMembers(SR1_Reader reader, SR1_Structure parent)
 		{

--- a/Recombobulator/SR1Structures/InGame/Instance.cs
+++ b/Recombobulator/SR1Structures/InGame/Instance.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class Instance : SR1_Structure
+	public class Instance : SR1_Structure
 	{
 		protected override void ReadMembers(SR1_Reader reader, SR1_Structure parent)
 		{

--- a/Recombobulator/SR1Structures/InGame/PointLight.cs
+++ b/Recombobulator/SR1Structures/InGame/PointLight.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class PointLight : SR1_Structure
+	public class PointLight : SR1_Structure
 	{
 		protected override void ReadMembers(SR1_Reader reader, SR1_Structure parent)
 		{

--- a/Recombobulator/SR1Structures/InGame/StreamUnit.cs
+++ b/Recombobulator/SR1Structures/InGame/StreamUnit.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class StreamUnit : SR1_Structure
+	public class StreamUnit : SR1_Structure
 	{
 		protected override void ReadMembers(SR1_Reader reader, SR1_Structure parent)
 		{

--- a/Recombobulator/SR1Structures/Pointers/SR1_Pointer.cs
+++ b/Recombobulator/SR1Structures/Pointers/SR1_Pointer.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class SR1_Pointer<T> : SR1_PointerBase where T : class, new()
+	public class SR1_Pointer<T> : SR1_PointerBase where T : class, new()
 	{
 		public override Type GetGenericType()
 		{

--- a/Recombobulator/SR1Structures/Pointers/SR1_PointerArrayPointer.cs
+++ b/Recombobulator/SR1Structures/Pointers/SR1_PointerArrayPointer.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class SR1_PointerArrayPointer<T> : SR1_PointerBase where T : SR1_Structure, new()
+	public class SR1_PointerArrayPointer<T> : SR1_PointerBase where T : SR1_Structure, new()
 	{
 		public override Type GetGenericType()
 		{

--- a/Recombobulator/SR1Structures/Pointers/SR1_PointerBase.cs
+++ b/Recombobulator/SR1Structures/Pointers/SR1_PointerBase.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	abstract class SR1_PointerBase : SR1_PrimativeBase
+	public abstract class SR1_PointerBase : SR1_PrimativeBase
 	{
 		public uint Offset { get; set; }
 

--- a/Recombobulator/SR1Structures/Pointers/SR1_PrimativePointer.cs
+++ b/Recombobulator/SR1Structures/Pointers/SR1_PrimativePointer.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class SR1_PrimativePointer<T> : SR1_PointerBase // where T : struct
+	public class SR1_PrimativePointer<T> : SR1_PointerBase // where T : struct
 	{
 		public override Type GetGenericType()
 		{

--- a/Recombobulator/SR1Structures/SR1_Primative.cs
+++ b/Recombobulator/SR1Structures/SR1_Primative.cs
@@ -4,9 +4,8 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	class SR1_Primative<T> : SR1_PrimativeBase // where T : struct
+	public class SR1_Primative<T> : SR1_PrimativeBase // where T : struct
 	{
-		protected bool _showAsHex;
 
 		public T Value { get; set; }
 

--- a/Recombobulator/SR1Structures/SR1_PrimativeBase.cs
+++ b/Recombobulator/SR1Structures/SR1_PrimativeBase.cs
@@ -4,8 +4,10 @@ using System.IO;
 
 namespace Recombobulator.SR1Structures
 {
-	abstract class SR1_PrimativeBase : SR1_Structure
+	public abstract class SR1_PrimativeBase : SR1_Structure
 	{
+		protected bool _showAsHex;
+
 		public virtual bool IsArray() { return false; }
 
 		protected override void Register(SR1_Writer writer)
@@ -19,6 +21,11 @@ namespace Recombobulator.SR1Structures
 			}
 
 			writer.File._Primatives.Add(Start, this);
+		}
+
+		public bool IsShowAsHex()
+		{
+			return _showAsHex;
 		}
 	}
 }

--- a/Recombobulator/SR1Structures/SR1_Structure.cs
+++ b/Recombobulator/SR1Structures/SR1_Structure.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 
 namespace Recombobulator.SR1Structures
 {
-	abstract class SR1_Structure
+	public abstract class SR1_Structure
 	{
 		public uint Start { get; protected set; }
 		public uint NewStart { get; protected set; }
@@ -17,7 +17,7 @@ namespace Recombobulator.SR1Structures
 
 		public string Name { get; protected set; }
 
-		protected List<SR1_Structure> MembersRead = new List<SR1_Structure>();
+		public readonly List<SR1_Structure> MembersRead = new List<SR1_Structure>();
 
 		private byte[] _padding = null;
 

--- a/Recombobulator/SR1_File.cs
+++ b/Recombobulator/SR1_File.cs
@@ -5,7 +5,7 @@ using Recombobulator.SR1Structures;
 
 namespace Recombobulator
 {
-	class SR1_File
+	public class SR1_File
 	{
 		public const UInt32 PROTO_19981025_VERSION = 0x00000000;
 		public const UInt32 ALPHA_19990123_VERSION_1_X = 0x3c204127;
@@ -18,6 +18,8 @@ namespace Recombobulator
 
 		public enum Version
 		{
+			Detect = -1,
+			Detect_Retail_PC = -2,
 			First = 0,
 			Alpha_1_X,
 			Alpha_1,
@@ -38,7 +40,6 @@ namespace Recombobulator
 			None = 0,
 			LogErrors = 1,
 			LogScripts = 2,
-			DetectPCRetail = 4,
 		}
 
 		public enum MigrateFlags : int
@@ -66,7 +67,7 @@ namespace Recombobulator
 			public readonly Dictionary<ushort, ushort> NewTextureIDs = new Dictionary<ushort, ushort>();
 			public int OldStreamUnitID;
 			public int NewStreamUnitID;
-            public readonly Dictionary<int, int> NewIntroIDs = new Dictionary<int, int>();
+			public readonly Dictionary<int, int> NewIntroIDs = new Dictionary<int, int>();
 			public readonly Dictionary<string, string> NewObjectNames = new Dictionary<string, string>();
 		}
 
@@ -107,17 +108,17 @@ namespace Recombobulator
 			_Overrides = null;
 		}
 
-		public void Import(string fileName, ImportFlags flags = ImportFlags.None | ImportFlags.DetectPCRetail)
+		public void Import(string fileName, ImportFlags flags = ImportFlags.None, Version forcedVersion = Version.Detect_Retail_PC)
 		{
 			_ImportFlags = flags;
 			_FilePath = fileName;
 
 			FileStream file = new FileStream(fileName, FileMode.Open, FileAccess.Read);
-			Import(file);
+			Import(file, forcedVersion);
 			file.Close();
 		}
 
-		private void Import(Stream inputStream)
+		private void Import(Stream inputStream, Version forcedVersion = Version.Detect)
 		{
 			Reset();
 
@@ -142,137 +143,55 @@ namespace Recombobulator
 
 			if (_IsLevel)
 			{
-				bool validVersion = false;
-
-				if (!validVersion && ((_ImportFlags & ImportFlags.DetectPCRetail) != 0))
+				if (forcedVersion == Version.Detect || forcedVersion == Version.Detect_Retail_PC)
 				{
-					dataReader.BaseStream.Position = 0x9C;
-					if (dataReader.ReadUInt64() == 0xFFFFFFFFFFFFFFFF)
+					bool validVersion = false;
+
+					if (!validVersion && forcedVersion == Version.Detect_Retail_PC)
 					{
-						_Version = Version.Retail_PC;
-						validVersion = true;
-					}
-				}
-
-				if (!validVersion)
-				{
-					dataReader.BaseStream.Position = 0xF0;
-					UInt32 version = dataReader.ReadUInt32();
-					if (!validVersion && version == RETAIL_VERSION)
-					{
-						_Version = Version.Jun01;
-						validVersion = true;
-					}
-
-					if (!validVersion && version == BETA_19990512_VERSION)
-					{
-						_Version = Version.May12;
-						validVersion = true;
-					}
-
-					if (!validVersion)
-					{
-						dataReader.BaseStream.Position = 0xE8;
-						version = dataReader.ReadUInt32();
-					}
-
-					if (!validVersion && version == ALPHA_19990414_VERSION_4)
-					{
-						_Version = Version.Apr14;
-						validVersion = true;
-					}
-
-					if (!validVersion)
-					{
-						dataReader.BaseStream.Position = 0xE4;
-						version = dataReader.ReadUInt32();
-					}
-
-					if (!validVersion && version == ALPHA_19990216_VERSION_3)
-					{
-						_Version = Version.Feb16;
-						validVersion = true;
-					}
-
-					if (!validVersion)
-					{
-						dataReader.BaseStream.Position = 0xE0;
-						version = dataReader.ReadUInt32();
-					}
-
-					if (!validVersion && version == ALPHA_19990204_VERSION_2)
-					{
-						_Version = Version.Feb04;
-						validVersion = true;
-					}
-				}
-
-				if (!validVersion)
-				{
-					_Version = Version.Jun01;
-					validVersion = true;
-				}
-
-				root = new SR1Structures.Level();
-			}
-			else
-			{
-				bool validVersion = false;
-
-				if (!validVersion)
-				{
-					dataReader.BaseStream.Position = 0x2C;
-					UInt32 oflags2 = dataReader.ReadUInt32();
-					if ((oflags2 & 0x00080000) != 0)
-					{
-						dataReader.BaseStream.Position = 0x1C;
-						UInt32 dataPos = dataReader.ReadUInt32();
-						if (dataPos != 0)
+						dataReader.BaseStream.Position = 0x9C;
+						if (dataReader.ReadUInt64() == 0xFFFFFFFFFFFFFFFF)
 						{
-							dataReader.BaseStream.Position = dataPos;
-							UInt32 magicNum = dataReader.ReadUInt32();
-							if (magicNum == 0xACE00065)
-							{
-								_Version = Version.Jul14;
-								validVersion = true;
-							}
-							else if (magicNum == 0xACE00064)
-							{
-								_Version = Version.Jun10;
-								validVersion = true;
-							}
-							else if (magicNum == 0xACE00063)
-							{
-								_Version = Version.Jun01;
-								validVersion = true;
-							}
-							else if (magicNum == 0xACE00062)
-							{
-								_Version = Version.May12;
-								validVersion = true;
-							}
-							else if (magicNum == 0xACE00060)
-							{
-								_Version = Version.Apr14;
-								validVersion = true;
-							}
-							else if (magicNum == 0xACE0005C)
-							{
-								_Version = Version.Feb16;
-								validVersion = true;
-							}
-							else if (magicNum == 0xACE0005B)
-							{
-								_Version = Version.Feb04;
-								validVersion = true;
-							}
+							_Version = Version.Retail_PC;
+							validVersion = true;
 						}
 					}
-					else
+
+					if (!validVersion)
 					{
-						dataReader.BaseStream.Position = 0x24;
-						uint namePos = dataReader.ReadUInt32();
-						if (namePos == 0x00000044)
+						dataReader.BaseStream.Position = 0xF0;
+						UInt32 version = dataReader.ReadUInt32();
+						if (!validVersion && version == RETAIL_VERSION)
+						{
+							_Version = Version.Jun01;
+							validVersion = true;
+						}
+
+						if (!validVersion && version == BETA_19990512_VERSION)
+						{
+							_Version = Version.May12;
+							validVersion = true;
+						}
+
+						if (!validVersion)
+						{
+							dataReader.BaseStream.Position = 0xE8;
+							version = dataReader.ReadUInt32();
+						}
+
+						if (!validVersion && version == ALPHA_19990414_VERSION_4)
+						{
+							_Version = Version.Apr14;
+							validVersion = true;
+						}
+
+						if (!validVersion)
+						{
+							dataReader.BaseStream.Position = 0xE4;
+							version = dataReader.ReadUInt32();
+						}
+
+						if (!validVersion && version == ALPHA_19990216_VERSION_3)
 						{
 							_Version = Version.Feb16;
 							validVersion = true;
@@ -280,69 +199,165 @@ namespace Recombobulator
 
 						if (!validVersion)
 						{
-							dataReader.BaseStream.Position = 0x50;
-							char[] objectName = dataReader.ReadChars(8);
-							string objectNameStr = new string(objectName);
-							if (objectNameStr == "flamegs_")
+							dataReader.BaseStream.Position = 0xE0;
+							version = dataReader.ReadUInt32();
+						}
+
+						if (!validVersion && version == ALPHA_19990204_VERSION_2)
+						{
+							_Version = Version.Feb04;
+							validVersion = true;
+						}
+					}
+
+					if (!validVersion)
+					{
+						_Version = Version.Jun01;
+						validVersion = true;
+					}
+				}
+				else
+				{
+					_Version = forcedVersion;
+				}
+
+				root = new SR1Structures.Level();
+			}
+			else
+			{
+				if (forcedVersion == Version.Detect || forcedVersion == Version.Detect_Retail_PC)
+				{
+					bool validVersion = false;
+
+					if (!validVersion)
+					{
+						dataReader.BaseStream.Position = 0x2C;
+						UInt32 oflags2 = dataReader.ReadUInt32();
+						if ((oflags2 & 0x00080000) != 0)
+						{
+							dataReader.BaseStream.Position = 0x1C;
+							UInt32 dataPos = dataReader.ReadUInt32();
+							if (dataPos != 0)
+							{
+								dataReader.BaseStream.Position = dataPos;
+								UInt32 magicNum = dataReader.ReadUInt32();
+								if (magicNum == 0xACE00065)
+								{
+									_Version = Version.Jul14;
+									validVersion = true;
+								}
+								else if (magicNum == 0xACE00064)
+								{
+									_Version = Version.Jun10;
+									validVersion = true;
+								}
+								else if (magicNum == 0xACE00063)
+								{
+									_Version = Version.Jun01;
+									validVersion = true;
+								}
+								else if (magicNum == 0xACE00062)
+								{
+									_Version = Version.May12;
+									validVersion = true;
+								}
+								else if (magicNum == 0xACE00060)
+								{
+									_Version = Version.Apr14;
+									validVersion = true;
+								}
+								else if (magicNum == 0xACE0005C)
+								{
+									_Version = Version.Feb16;
+									validVersion = true;
+								}
+								else if (magicNum == 0xACE0005B)
+								{
+									_Version = Version.Feb04;
+									validVersion = true;
+								}
+							}
+						}
+						else
+						{
+							dataReader.BaseStream.Position = 0x24;
+							uint namePos = dataReader.ReadUInt32();
+							if (namePos == 0x00000044)
 							{
 								_Version = Version.Feb16;
 								validVersion = true;
 							}
-						}
 
-						if (!validVersion)
-						{
-							dataReader.BaseStream.Position = 0x4C;
-							char[] objectName = dataReader.ReadChars(8);
-							string objectNameStr = new string(objectName);
-
-							if (objectNameStr == "particle")
+							if (!validVersion)
 							{
-								dataReader.BaseStream.Position = 0x0424;
-								if (dataReader.ReadUInt32() == 0x00000440 &&
-									dataReader.ReadUInt32() == 0x00003000 &&
-									dataReader.ReadUInt32() == 0x00003150 &&
-									dataReader.ReadUInt32() == 0x0000355C &&
-									dataReader.ReadUInt32() == 0x00003B60 &&
-									dataReader.ReadUInt32() == 0x00003EE8 &&
-									dataReader.ReadUInt32() == 0x00003EA0)
+								dataReader.BaseStream.Position = 0x50;
+								char[] objectName = dataReader.ReadChars(8);
+								string objectNameStr = new string(objectName);
+								if (objectNameStr == "flamegs_")
 								{
-									_Version = Version.May12;
+									_Version = Version.Feb16;
+									validVersion = true;
 								}
-								else
-								{
-									_Version = Version.Jun01;
-								}
-
-								validVersion = true;
 							}
-							else if (objectNameStr == "force___")
-							{
-								dataReader.BaseStream.Position = 0x1730;
-								if (dataReader.BaseStream.Length >= 0x173C &&
-                                    dataReader.ReadUInt16() == 0x2FDD &&
-									dataReader.ReadUInt16() == 0x0007 &&
-									dataReader.ReadUInt16() == 0xB00B &&
-									dataReader.ReadUInt16() == 0x8000 &&
-									dataReader.ReadUInt32() == 0x0000000C)
-								{
-									_Version = Version.Apr14;
-								}
-								else
-								{
-									_Version = Version.Jun01;
-								}
 
-								validVersion = true;
+							if (!validVersion)
+							{
+								dataReader.BaseStream.Position = 0x4C;
+								char[] objectName = dataReader.ReadChars(8);
+								string objectNameStr = new string(objectName);
+
+								if (objectNameStr == "particle")
+								{
+									dataReader.BaseStream.Position = 0x0424;
+									if (dataReader.ReadUInt32() == 0x00000440 &&
+										dataReader.ReadUInt32() == 0x00003000 &&
+										dataReader.ReadUInt32() == 0x00003150 &&
+										dataReader.ReadUInt32() == 0x0000355C &&
+										dataReader.ReadUInt32() == 0x00003B60 &&
+										dataReader.ReadUInt32() == 0x00003EE8 &&
+										dataReader.ReadUInt32() == 0x00003EA0)
+									{
+										_Version = Version.May12;
+									}
+									else
+									{
+										_Version = Version.Jun01;
+									}
+
+									validVersion = true;
+								}
+								else if (objectNameStr == "force___")
+								{
+									dataReader.BaseStream.Position = 0x1730;
+									if (dataReader.BaseStream.Length >= 0x173C &&
+										dataReader.ReadUInt16() == 0x2FDD &&
+										dataReader.ReadUInt16() == 0x0007 &&
+										dataReader.ReadUInt16() == 0xB00B &&
+										dataReader.ReadUInt16() == 0x8000 &&
+										dataReader.ReadUInt32() == 0x0000000C)
+									{
+										_Version = Version.Apr14;
+									}
+									else
+									{
+										_Version = Version.Jun01;
+									}
+
+									validVersion = true;
+								}
 							}
 						}
 					}
-				}
 
-				if (!validVersion)
+					if (!validVersion)
+					{
+						_Version = Version.Jun01;
+						validVersion = true;
+					}
+				}
+				else
 				{
-					_Version = Version.Jun01;
-					validVersion = true;
+					_Version = forcedVersion;
 				}
 
 				root = new SR1Structures.Object();

--- a/Recombobulator/SR1_Reader.cs
+++ b/Recombobulator/SR1_Reader.cs
@@ -4,7 +4,7 @@ using Recombobulator.SR1Structures;
 
 namespace Recombobulator
 {
-	class SR1_Reader : BinaryReader
+	public class SR1_Reader : BinaryReader
 	{
 		public SR1_File File = null;
 		public Level Level = null;

--- a/Recombobulator/SR1_Writer.cs
+++ b/Recombobulator/SR1_Writer.cs
@@ -4,7 +4,7 @@ using Recombobulator.SR1Structures;
 
 namespace Recombobulator
 {
-	class SR1_Writer : BinaryWriter
+	public class SR1_Writer : BinaryWriter
 	{
 		public SR1_File File = null;
 		public StringWriter Errors = new StringWriter();

--- a/Recombobulator/ScriptParser.cs
+++ b/Recombobulator/ScriptParser.cs
@@ -3,7 +3,7 @@ using Recombobulator.SR1Structures;
 
 namespace Recombobulator
 {
-	class ScriptParser
+	public class ScriptParser
 	{
 		enum ScriptType : sbyte
 		{


### PR DESCRIPTION
Add Edit Particles form

Work on particle editing form.

Added toolbox and ability to select current index.

More work on particle editing.

Added copy, paste, backup, reset functionality for particle edit form.

Add a panel rather than a form for particles.

Removed EditParticlesForm now that a panel us used instead.

Disabling things that should be to begin with.

Reorganized menu items to account for particles being a separate thing from data files.

Added particles saving.

No saving unless there's something to save.

Added panels for other types of 'particle' effect.

Separate menu items for file types.

Fix up tabs in mainform.

Added panels for other categories of particle.

Added ability to select the correct manel for the current particle type.

Correcting labels for particle panels.

Updated panels to hold the correct data types.

Implement copying for blast rings and flashes.

Implement copying for ribbons.

Implement copying for glows.

Implemented copying for lightning.

Made a lot of classes public, fixed  a bug in filling out forms, added recursive handling for vectors.

Matched changes to selectionComboBox_SelectedIndexChanged for all particle types.

Updates to show ribbon colors and hex values.

Updates to show lightning colors and hex values.

Updates to show flash colors and hex values.